### PR TITLE
fix(build): extend other Vis libraries

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,6 +42,7 @@ export default [
       format: 'umd',
       exports: 'named',
       name: 'vis',
+      extend: true
     },
     plugins: [
       resolve(resolveConfig),


### PR DESCRIPTION
They were overwritten before which resulted in only one Vis library being usable at a time.

Addresses: https://github.com/visjs/vis-network/issues/66.