### PR TITLE
style: fix some issues with 2.0.0 TypeScript ESLint update

### DIFF
--- a/src/data-view.ts
+++ b/src/data-view.ts
@@ -86,7 +86,7 @@ export class DataView<
   IdProp extends string = "id"
 > extends DataSetPart<Item, IdProp> implements DataInterface<Item, IdProp> {
   /** @inheritdoc */
-  public length: number = 0;
+  public length = 0;
   private readonly _listener: EventCallbacksWithAny<Item, IdProp>["*"];
 
   private _data!: DataInterface<Item, IdProp>; // constructor → setData

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -177,6 +177,7 @@ export class Queue<T = never> {
     object: Record<M, () => void>,
     method: M
   ): void {
+    /* eslint-disable-next-line @typescript-eslint/no-this-alias */
     const me = this;
     const original = object[method];
     if (!original) {


### PR DESCRIPTION
These (and maybe also other) rules are now enabled by default:
- @typescript-eslint/no-inferrable-types
- @typescript-eslint/no-this-alias

Should hopefully address #14.