### PR TITLE
chore(deps): pin runtime dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     }
   },
   "dependencies": {
-    "vis-util": "^1.1.0"
+    "vis-util": "1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     }
   },
   "dependencies": {
-    "vis-util": "1.1.0"
+    "vis-util": "1.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.5.4",


### PR DESCRIPTION
Greenkeeper doesn't open a PR when the new version satisfies the range and works. Therefore we receive issues if something breaks and PRs for breaking changes but not for features or fixes. This will make Greenkeeper open a PR for every release.