### PR TITLE
Adding duplicate items via array adds the rest of the array before throwing the error.

### DIFF
--- a/src/data-set.ts
+++ b/src/data-set.ts
@@ -254,13 +254,18 @@ export class DataSet<
    */
   public add(data: Item | Item[], senderId?: Id | null): (string | number)[] {
     const addedIds: Id[] = [];
+    const duplicates: Item[] = [];
     let id: Id;
 
     if (Array.isArray(data)) {
       // Array
       for (let i = 0, len = data.length; i < len; i++) {
-        id = this._addItem(data[i]);
-        addedIds.push(id);
+        try {
+          id = this._addItem(data[i]);
+          addedIds.push(id);
+        } catch (error) {
+          duplicates.push(data[i]);
+        }
       }
     } else if (data && typeof data === "object") {
       // Single item
@@ -272,6 +277,13 @@ export class DataSet<
 
     if (addedIds.length) {
       this._trigger("add", { items: addedIds }, senderId);
+    }
+
+    if (duplicates.length) {
+      throw new Error(
+        "Some duplicate ids were unable to be added to the dataset: " +
+          duplicates.map(i => i[this._idProp])
+      );
     }
 
     return addedIds;

--- a/src/data-set.ts
+++ b/src/data-set.ts
@@ -254,18 +254,17 @@ export class DataSet<
    */
   public add(data: Item | Item[], senderId?: Id | null): (string | number)[] {
     const addedIds: Id[] = [];
-    const duplicates: Item[] = [];
     let id: Id;
 
     if (Array.isArray(data)) {
       // Array
+      const idsToAdd: Id[] = data.map(d => d[this._idProp] as Id);
+      if (idsToAdd.some(id => this._data.has(id))) {
+        throw new Error("A duplicate id was found in the parameter array.");
+      }
       for (let i = 0, len = data.length; i < len; i++) {
-        try {
-          id = this._addItem(data[i]);
-          addedIds.push(id);
-        } catch (error) {
-          duplicates.push(data[i]);
-        }
+        id = this._addItem(data[i]);
+        addedIds.push(id);
       }
     } else if (data && typeof data === "object") {
       // Single item
@@ -277,13 +276,6 @@ export class DataSet<
 
     if (addedIds.length) {
       this._trigger("add", { items: addedIds }, senderId);
-    }
-
-    if (duplicates.length) {
-      throw new Error(
-        "Some duplicate ids were unable to be added to the dataset: " +
-          duplicates.map(i => i[this._idProp])
-      );
     }
 
     return addedIds;

--- a/test/DataSet.test.js
+++ b/test/DataSet.test.js
@@ -316,6 +316,14 @@ describe('DataSet', function () {
       assert.throws(function () { dataset.add(null) }, Error, "null type throws error");
       assert.throws(function () { dataset.add(undefined) }, Error, "undefined type throws error");
     });
+
+    it('throws an error when passed a duplicate id, but adds the rest of the array', () => {
+      const dataset = new DataSet([{id: 1}, {id: 2}]);
+      assert.throws(() => {
+        dataset.add([{id: 3}, {id: 1}, {id: 4}, {id: 5}]), Error, "duplicate ids throws error."
+      });
+      assert.deepStrictEqual(dataset.getIds(), [1, 2, 3, 4, 5]);
+    });
   });
 
   describe('setOptions', function () {

--- a/test/DataSet.test.js
+++ b/test/DataSet.test.js
@@ -317,12 +317,12 @@ describe('DataSet', function () {
       assert.throws(function () { dataset.add(undefined) }, Error, "undefined type throws error");
     });
 
-    it('throws an error when passed a duplicate id, but adds the rest of the array', () => {
+    it('throws an error when passed a duplicate id', () => {
       const dataset = new DataSet([{id: 1}, {id: 2}]);
       assert.throws(() => {
         dataset.add([{id: 3}, {id: 1}, {id: 4}, {id: 5}]), Error, "duplicate ids throws error."
       });
-      assert.deepStrictEqual(dataset.getIds(), [1, 2, 3, 4, 5]);
+      assert.deepStrictEqual(dataset.getIds(), [1, 2]);
     });
   });
 


### PR DESCRIPTION
Ran into this issue while doing some batch adds on DataSet:

If a duplicate id is found for an item in an array being added, the dataset will add all of the items prior to the duplicate, then bail out of the add function when the duplicate is hit.

This change allows the `DataSet.add(data: Item | Item[])` function to add all of the non-duplicates to the dataset, fire off the add event (with the added ids), and then finally error out with a list of duplicate ids.

The function, in this form, will still return an `Error` instead of the list of added Ids, but at least this way the listeners will still get the news that things have been added.

There also might be an opportunity for something like an `ignoreDuplicates: boolean` optional parameter here that could either Error (without adding anything to the dataset) if set to false, or not error at all and drop the duplicates. Curious what others think about this, compared to the current behaviour.

Oh, also-- the pre-PR checklist said to point PRs to `develop`-- but it looks like that branch doesn't exist?