### PR TITLE
feat(data-pipe): pipe data between data sets

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,1 @@
-{
-  "parser": "typescript"
-}
+{}

--- a/docs/data/datapipe.html
+++ b/docs/data/datapipe.html
@@ -1,0 +1,551 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="" />
+    <meta name="author" content="" />
+    <link rel="icon" href="favicon.ico" />
+
+    <title>
+      DataPipe - vis.js - A dynamic, browser based visualization library.
+    </title>
+
+    <!-- Bootstrap core CSS -->
+    <link href="../css/bootstrap.css" rel="stylesheet" />
+    <!-- Tipue vendor css -->
+    <link href="../css/tipuesearch.css" rel="stylesheet" />
+
+    <link href="../css/style.css" rel="stylesheet" />
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+    <link href="../css/prettify.css" type="text/css" rel="stylesheet" />
+    <script type="text/javascript" src="../js/prettify/prettify.js"></script>
+
+    <script src="../js/smooth-scroll.min.js"></script>
+    <script language="JavaScript">
+      smoothScroll.init();
+    </script>
+
+    <script type="text/javascript" src="../js/toggleTable.js"></script>
+  </head>
+
+  <body onload="prettyPrint();">
+    <div class="navbar-wrapper">
+      <div class="container">
+        <nav class="navbar navbar-inverse navbar-static-top" role="navigation">
+          <div class="container">
+            <div class="navbar-header">
+              <button
+                type="button"
+                class="navbar-toggle collapsed"
+                data-toggle="collapse"
+                data-target="#navbar"
+                aria-expanded="false"
+                aria-controls="navbar"
+              >
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+              </button>
+              <a class="navbar-brand hidden-sm" href="./index.html">vis.js</a>
+            </div>
+            <div id="navbar" class="navbar-collapse collapse">
+              <ul class="nav navbar-nav"></ul>
+              <form class="navbar-form navbar-right" role="search">
+                <input
+                  name="q"
+                  id="tipue_search_input"
+                  autocomplete="off"
+                  type="text"
+                  class="form-control"
+                  placeholder="Enter keywords"
+                />
+                <button type="submit" class="btn btn-default">Go!</button>
+              </form>
+              <div id="search-results-wrapper" class="panel panel-default">
+                <div class="panel-body">
+                  <div id="tipue_search_content"></div>
+                </div>
+              </div>
+              <div id="keyword-info" class="panel panel-success">
+                <div class="panel-body">
+                  Found <span id="keyword-count"></span> results. Click
+                  <a id="keyword-jumper-button" href="">here</a> to jump to the
+                  first keyword occurence!
+                </div>
+              </div>
+            </div>
+          </div>
+        </nav>
+      </div>
+    </div>
+
+    <div class="container full">
+      <h1>DataPipe</h1>
+
+      <h2 id="Contents">Contents</h2>
+      <ul>
+        <li><a href="#Overview">Overview</a></li>
+        <li><a href="#Example">Example</a></li>
+        <li><a href="#Construction">Construction</a></li>
+        <li><a href="#Methods">Methods</a></li>
+        <li><a href="#TypeCoercion">Type Coercion</a></li>
+      </ul>
+
+      <h2 id="Overview">Overview</h2>
+
+      <p>
+        A <a href="datapipe.html">DataPipe</a> offers a way of piping and
+        transforming items from one <a href="dataset.html">DataSet</a> into
+        another <a href="dataset.html">DataSet</a>. It can be used to coerce
+        data types, change structure or even generate brand new items based on
+        some data specific to your problem.
+      </p>
+
+      <h2 id="Example">Example</h2>
+
+      <p>
+        The following example shows how to use a
+        <a href="datapipe.html">DataPipe</a> to divide app specific and Vis
+        specific data to prevent name collisions (like having app specific and
+        Vis specific labels).
+      </p>
+
+      <pre class="prettyprint lang-js">
+// TypeScript interfaces to illustrate the structure of the data:
+//
+// interface appDSItem {
+//   id: number | string;
+//
+//   appLabel: string;
+//   appPosition: number;
+//
+//   visLabel: string;
+//   visColor: string;
+//   visX: number;
+//   visY: number;
+// }
+//
+// interface VisDSItem {
+//   id: number | string;
+//   label: string;
+//   color: string;
+//   x: number;
+//   y: number;
+// }
+
+const appDS = new DataSet([
+  /* some app data */
+]);
+const visDS = new DataSet();
+
+const pipe = createNewDataPipeFrom(appDS)
+  // All items can be arbitrarily transformed.
+  .map((item) => ({
+    id: item.id,
+    label: item.visLabel,
+    color: item.visColor,
+    x: item.visX,
+    y: item.visY
+  }))
+  // This builds and returns the pipe from appDS to visDS.
+  .to(visDS);
+
+pipe.all().start();
+// All items were transformed and piped into visDS and all later changes
+// will be transformed and piped as well.
+</pre
+      >
+
+      <h2 id="Construction">Construction</h2>
+
+      <p>A <a href="datapipe.html">DataPipe</a> can be constructed as:</p>
+
+      <pre class="prettyprint lang-js">
+const pipe = createNewDataPipeFrom(sourceDataSet)
+  .filter(item => item.enabled === true)
+  .map(item => ({
+    /* some new item */
+  }))
+  .flatMap(item => [
+    /* zero or more new items */
+  ])
+  .to(targetDataSet);
+</pre
+      >
+
+      <p>where:</p>
+
+      <ul>
+        <li>
+          <code>sourceDataSet</code> is a <a href="dataset.html">DataSet</a> or
+          <a href="dataview.html">DataView</a> that will supply the items into
+          the pipe line.
+        </li>
+        <li>
+          <code>targetDataSet</code> is a
+          <a href="dataset.html">DataSet</a> that will receive the processed
+          items from the pipe line.
+        </li>
+        <li>
+          <code>.filter</code>'s argument is a function that takes an item from
+          the pipe as it's argument and returns true if the item should be
+          processed further down the pipe line or false if it should be skipped.
+        </li>
+        <li>
+          <code>.map</code>'s argument is a function that takes an item from the
+          pipe as it's argument and returns a new item that will be processed
+          further down the pipe line.
+        </li>
+        <li>
+          <code>.flatMap</code>'s argument is a function that takes an item from
+          the pipe as it's argument and returns an array of zero or more items
+          that will be processed further down the pipe line.
+        </li>
+      </ul>
+
+      <p>
+        Note that the items are passed through the pipe in the order in which
+        the factory methods (<code>.filter</code>, <code>.map</code> and
+        <code>.flatMap</code>) were called. Also note that it's possible to use
+        the same method multiple times (for example <code>.filter</code>,
+        <code>.map</code> and <code>.filter</code> again) or only use some of
+        them (for example <code>.filter</code> and <code>.map</code> but no
+        <code>.flatMap</code>).
+      </p>
+
+      <h2 id="Methods">Methods</h2>
+
+      <p>
+        <a href="datapipe.html">DataPipe</a> contains the following methods.
+      </p>
+
+      <table class="methods">
+        <tr>
+          <th>Method</th>
+          <th>Return Type</th>
+          <th>Description</th>
+        </tr>
+
+        <tr>
+          <td>all()</td>
+          <td>this</td>
+          <td>
+            Sends all the data from the source
+            <a href="dataset.html">DataSet</a> or
+            <a href="dataview.html">DataView</a> down the pipe line.
+          </td>
+        </tr>
+
+        <tr>
+          <td>start()</td>
+          <td>this</td>
+          <td>
+            Starts observing the changes in the source
+            <a href="dataset.html">DataSet</a> or
+            <a href="dataview.html">DataView</a> and sending them down the pipe
+            line as they happen.
+          </td>
+        </tr>
+
+        <tr>
+          <td>stop()</td>
+          <td>this</td>
+          <td>
+            Stops observing changes in the source
+            <a href="dataset.html">DataSet</a> or
+            <a href="dataview.html">DataView</a>.
+          </td>
+        </tr>
+      </table>
+
+      <h2 id="TypeCoercion">Type Coercion</h2>
+
+      <p>
+        <a href="datapipe.html">DataPipe</a> can be used as a replacement for
+        the now deprecated type coercion of
+        <a href="dataset.html">DataSets</a> (configured by the
+        <code>type</code> constructor parameter).
+      </p>
+
+      <pre class="prettyprint lang-js">
+// --[BEGIN]-- The original implementation of type coercion.
+
+// !!!! Make sure to import Moment.js as this code depends on it.
+const convert = (() => {
+  // parse ASP.Net Date pattern,
+  // for example '/Date(1198908717056)/' or '/Date(1198908717056-0700)/'
+  // code from http://momentjs.com/
+  const ASPDateRegex = /^\/?Date\((-?\d+)/i;
+
+  /**
+   * Test whether given object is a number
+   *
+   * @param value - Input value of unknown type.
+   *
+   * @returns True if number, false otherwise.
+   */
+  function isNumber(value) {
+    return value instanceof Number || typeof value === "number";
+  }
+
+  /**
+   * Test whether given object is a string
+   *
+   * @param value - Input value of unknown type.
+   *
+   * @returns True if string, false otherwise.
+   */
+  function isString(value) {
+    return value instanceof String || typeof value === "string";
+  }
+
+  /**
+   * Get the type of an object, for example exports.getType([]) returns 'Array'
+   *
+   * @param object - Input value of unknown type.
+   *
+   * @returns Detected type.
+   */
+  function getType(object) {
+    const type = typeof object;
+
+    if (type === "object") {
+      if (object === null) {
+        return "null";
+      }
+      if (object instanceof Boolean) {
+        return "Boolean";
+      }
+      if (object instanceof Number) {
+        return "Number";
+      }
+      if (object instanceof String) {
+        return "String";
+      }
+      if (Array.isArray(object)) {
+        return "Array";
+      }
+      if (object instanceof Date) {
+        return "Date";
+      }
+
+      return "Object";
+    }
+    if (type === "number") {
+      return "Number";
+    }
+    if (type === "boolean") {
+      return "Boolean";
+    }
+    if (type === "string") {
+      return "String";
+    }
+    if (type === undefined) {
+      return "undefined";
+    }
+
+    return type;
+  }
+
+  /**
+   * Convert an object into another type
+   *
+   * @param object - Value of unknown type.
+   * @param type - Name of the desired type.
+   *
+   * @returns Object in the desired type.
+   * @throws Error
+   */
+  return function convert(object, type) {
+    let match;
+
+    if (object === undefined) {
+      return undefined;
+    }
+    if (object === null) {
+      return null;
+    }
+
+    if (!type) {
+      return object;
+    }
+    if (!(typeof type === "string") && !(type instanceof String)) {
+      throw new Error("Type must be a string");
+    }
+
+    //noinspection FallthroughInSwitchStatementJS
+    switch (type) {
+      case "boolean":
+      case "Boolean":
+        return Boolean(object);
+
+      case "number":
+      case "Number":
+        if (isString(object) && !isNaN(Date.parse(object))) {
+          return moment(object).valueOf();
+        } else {
+          // @TODO: I don't think that Number and String constructors are a good idea.
+          // This could also fail if the object doesn't have valueOf method or if it's redefined.
+          // For example: Object.create(null) or { valueOf: 7 }.
+          return Number(object.valueOf());
+        }
+      case "string":
+      case "String":
+        return String(object);
+
+      case "Date":
+        if (isNumber(object)) {
+          return new Date(object);
+        }
+        if (object instanceof Date) {
+          return new Date(object.valueOf());
+        } else if (moment.isMoment(object)) {
+          return new Date(object.valueOf());
+        }
+        if (isString(object)) {
+          match = ASPDateRegex.exec(object);
+          if (match) {
+            // object is an ASP date
+            return new Date(Number(match[1])); // parse number
+          } else {
+            return moment(new Date(object)).toDate(); // parse string
+          }
+        } else {
+          throw new Error(
+            "Cannot convert object of type " + getType(object) + " to type Date"
+          );
+        }
+
+      case "Moment":
+        if (isNumber(object)) {
+          return moment(object);
+        }
+        if (object instanceof Date) {
+          return moment(object.valueOf());
+        } else if (moment.isMoment(object)) {
+          return moment(object);
+        }
+        if (isString(object)) {
+          match = ASPDateRegex.exec(object);
+          if (match) {
+            // object is an ASP date
+            return moment(Number(match[1])); // parse number
+          } else {
+            return moment(object); // parse string
+          }
+        } else {
+          throw new Error(
+            "Cannot convert object of type " + getType(object) + " to type Date"
+          );
+        }
+
+      case "ISODate":
+        if (isNumber(object)) {
+          return new Date(object);
+        } else if (object instanceof Date) {
+          return object.toISOString();
+        } else if (moment.isMoment(object)) {
+          return object.toDate().toISOString();
+        } else if (isString(object)) {
+          match = ASPDateRegex.exec(object);
+          if (match) {
+            // object is an ASP date
+            return new Date(Number(match[1])).toISOString(); // parse number
+          } else {
+            return moment(object).format(); // ISO 8601
+          }
+        } else {
+          throw new Error(
+            "Cannot convert object of type " +
+              getType(object) +
+              " to type ISODate"
+          );
+        }
+
+      case "ASPDate":
+        if (isNumber(object)) {
+          return "/Date(" + object + ")/";
+        } else if (object instanceof Date || moment.isMoment(object)) {
+          return "/Date(" + object.valueOf() + ")/";
+        } else if (isString(object)) {
+          match = ASPDateRegex.exec(object);
+          let value;
+          if (match) {
+            // object is an ASP date
+            value = new Date(Number(match[1])).valueOf(); // parse number
+          } else {
+            value = new Date(object).valueOf(); // parse string
+          }
+          return "/Date(" + value + ")/";
+        } else {
+          throw new Error(
+            "Cannot convert object of type " +
+              getType(object) +
+              " to type ASPDate"
+          );
+        }
+
+      default:
+        throw new Error(`Unknown type ${type}`);
+    }
+  };
+})();
+
+// --[END]-- The original implementation of type coercion.
+
+const rawDS = new DataSet([
+  /* raw data with arbitrary types */
+  { id: 7, label: 4, date: "2017-09-04" },
+  { id: false, label: 4, date: "2017-10-04" },
+  { id: "test", label: true, date: "2017-11-04" }
+]);
+const coercedDS = new DataSet(/* the data with coerced types will be piped here */);
+
+const types = {
+  id: "string",
+  label: "string",
+  date: "Date"
+};
+
+const pipe = createNewDataPipeFrom(rawDS)
+  .map(item =>
+    Object.keys(item).reduce((acc, key) => {
+      acc[key] = convert(item[key], types[key]);
+      return acc;
+    }, {})
+  )
+  .to(coercedDS);
+
+pipe.all().start();
+// All items were transformed and piped into visDS and all later changes
+// will be transformed and piped as well.
+</pre
+      >
+    </div>
+
+    <!-- Bootstrap core JavaScript
+================================================== -->
+    <!-- Placed at the end of the document so the pages load faster -->
+    <script src="../js/jquery.min.js"></script>
+    <script src="../js/bootstrap.min.js"></script>
+    <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
+    <script src="../js/ie10-viewport-bug-workaround.js"></script>
+    <!-- jquery extensions -->
+    <script src="../js/jquery.highlight.js"></script>
+    <script src="../js/jquery.url.min.js"></script>
+    <!-- Tipue vendor js -->
+    <script src="../js/tipuesearch.config.js"></script>
+    <script src="../js/tipuesearch.js"></script>
+    <!-- controller -->
+    <script src="../js/main.js"></script>
+  </body>
+</html>

--- a/docs/data/index.html
+++ b/docs/data/index.html
@@ -110,6 +110,18 @@
     <a href="dataview.html">Go to the documentation of DataView</a>
   </p>
 
+  <h2>DataPipe</h2>
+
+  <p>
+    A <code>DataPipe</code> fetches data from one <code>DataSet</code> or
+    <code>DataView</code>, transforms them and feeds them into second
+    <code>DataSet</code>.
+  </p>
+
+  <p>
+    <a href="datapipe.html">Go to the documentation of DataPipe</a>
+  </p>
+
 </div>
 
 <!-- Bootstrap core JavaScript

--- a/src/data-pipe.ts
+++ b/src/data-pipe.ts
@@ -1,0 +1,296 @@
+/* eslint @typescript-eslint/member-ordering: ["error", { "classes": ["field", "constructor", "method"] }] */
+
+import { DataInterface, EventCallbacks, PartItem } from "./data-interface";
+import { DataSet } from "./data-set";
+
+/**
+ * This interface is used to control the pipe.
+ */
+export interface DataPipe {
+  /**
+   * Take all items from the source data set or data view, transform them as
+   * configured and update the target data set.
+   */
+  all(): this;
+
+  /**
+   * Start observing the source data set or data view, transforming the items
+   * and updating the target data set.
+   *
+   * @remarks
+   * The current content of the source data set will be ignored. If you for
+   * example want to process all the items that are already there use:
+   * `pipe.all().start()`.
+   */
+  start(): this;
+
+  /**
+   * Stop observing the source data set or data view, transforming the items
+   * and updating the target data set.
+   */
+  stop(): this;
+}
+
+/**
+ * This interface is used to construct the pipe.
+ */
+export type DataPipeFactory = InstanceType<typeof DataPipeUnderConstruction>;
+
+/**
+ * Create new data pipe.
+ *
+ * @param from - The source data set or data view.
+ *
+ * @remarks
+ * Example usage:
+ * ```typescript
+ * interface AppItem {
+ *   whoami: string;
+ *   appData: unknown;
+ *   visData: VisItem;
+ * }
+ * interface VisItem {
+ *   id: number;
+ *   label: string;
+ *   color: string;
+ *   x: number;
+ *   y: number;
+ * }
+ *
+ * const ds1 = new DataSet<AppItem, "whoami">([], { fieldId: "whoami" });
+ * const ds2 = new DataSet<VisItem, "id">();
+ *
+ * const pipe = createNewDataPipeFrom(ds1)
+ *   .filter((item): boolean => item.enabled === true)
+ *   .map<VisItem, "id">((item): VisItem => item.visData)
+ *   .to(ds2);
+ *
+ * pipe.start();
+ * ```
+ *
+ * @returns A factory whose methods can be used to configure the pipe.
+ */
+export function createNewDataPipeFrom<
+  SI extends PartItem<SP>,
+  SP extends string = "id"
+>(from: DataInterface<SI, SP>): DataPipeUnderConstruction<SI, SP> {
+  return new DataPipeUnderConstruction(from);
+}
+
+type Transformer<T> = (input: T[]) => T[];
+
+/**
+ * Internal implementation of the pipe. This should be accessible only through
+ * `createNewDataPipeFrom` from the outside.
+ *
+ * @typeparam SI - Source item type.
+ * @typeparam SP - Source item type's id property name.
+ * @typeparam TI - Target item type.
+ * @typeparam TP - Target item type's id property name.
+ */
+class SimpleDataPipe<
+  SI extends PartItem<SP>,
+  SP extends string,
+  TI extends PartItem<TP>,
+  TP extends string
+> implements DataPipe {
+  /**
+   * Bound listeners for use with `DataInterface['on' | 'off']`.
+   */
+  private readonly _listeners: EventCallbacks<SI, SP> = {
+    add: this._add.bind(this),
+    remove: this._remove.bind(this),
+    update: this._update.bind(this)
+  };
+
+  /**
+   * Create a new data pipe.
+   *
+   * @param _source - The data set or data view that will be observed.
+   * @param _transformers - An array of transforming functions to be used to
+   * filter or transform the items in the pipe.
+   * @param _target - The data set or data view that will receive the items.
+   */
+  public constructor(
+    private readonly _source: DataInterface<SI, SP>,
+    private readonly _transformers: readonly Transformer<unknown>[],
+    private readonly _target: DataSet<TI, TP>
+  ) {}
+
+  /** @inheritdoc */
+  public all(): this {
+    this._target.update(this._transformItems(this._source.get()));
+    return this;
+  }
+
+  /** @inheritdoc */
+  public start(): this {
+    this._source.on("add", this._listeners.add);
+    this._source.on("remove", this._listeners.remove);
+    this._source.on("update", this._listeners.update);
+
+    return this;
+  }
+
+  /** @inheritdoc */
+  public stop(): this {
+    this._source.off("add", this._listeners.add);
+    this._source.off("remove", this._listeners.remove);
+    this._source.off("update", this._listeners.update);
+
+    return this;
+  }
+
+  /**
+   * Apply the transformers to the items.
+   *
+   * @param items - The items to be transformed.
+   *
+   * @returns The transformed items.
+   */
+  private _transformItems(items: unknown[]): any[] {
+    return this._transformers.reduce((items, transform): unknown[] => {
+      return transform(items);
+    }, items);
+  }
+
+  /**
+   * Handle an add event.
+   *
+   * @param _name - Ignored.
+   * @param payload - The payload containing the ids of the added items.
+   */
+  private _add(
+    _name: Parameters<EventCallbacks<SI, SP>["add"]>[0],
+    payload: Parameters<EventCallbacks<SI, SP>["add"]>[1]
+  ): void {
+    if (payload == null) {
+      return;
+    }
+
+    this._target.add(this._transformItems(this._source.get(payload.items)));
+  }
+
+  /**
+   * Handle an update event.
+   *
+   * @param _name - Ignored.
+   * @param payload - The payload containing the ids of the updated items.
+   */
+  private _update(
+    _name: Parameters<EventCallbacks<SI, SP>["update"]>[0],
+    payload: Parameters<EventCallbacks<SI, SP>["update"]>[1]
+  ): void {
+    if (payload == null) {
+      return;
+    }
+
+    this._target.update(this._transformItems(this._source.get(payload.items)));
+  }
+
+  /**
+   * Handle a remove event.
+   *
+   * @param _name - Ignored.
+   * @param payload - The payload containing the data of the removed items.
+   */
+  private _remove(
+    _name: Parameters<EventCallbacks<SI, SP>["remove"]>[0],
+    payload: Parameters<EventCallbacks<SI, SP>["remove"]>[1]
+  ): void {
+    if (payload == null) {
+      return;
+    }
+
+    this._target.remove(this._transformItems(payload.oldData));
+  }
+}
+
+/**
+ * Internal implementation of the pipe factory. This should be accessible
+ * only through `createNewDataPipeFrom` from the outside.
+ *
+ * @typeparam TI - Target item type.
+ * @typeparam TP - Target item type's id property name.
+ */
+class DataPipeUnderConstruction<
+  SI extends PartItem<SP>,
+  SP extends string = "id"
+> {
+  /**
+   * Array transformers used to transform items within the pipe. This is typed
+   * as any for the sake of simplicity.
+   */
+  private readonly _transformers: Transformer<any>[] = [];
+
+  /**
+   * Create a new data pipe factory. This is an internal constructor that
+   * should never be called from outside of this file.
+   *
+   * @param _source - The source data set or data view for this pipe.
+   */
+  public constructor(private readonly _source: DataInterface<SI, SP>) {}
+
+  /**
+   * Filter the items.
+   *
+   * @param callback - A filtering function that returns true if given item
+   * should be piped and false if not.
+   *
+   * @returns This factory for further configuration.
+   */
+  public filter(
+    callback: (item: SI) => boolean
+  ): DataPipeUnderConstruction<SI, SP> {
+    this._transformers.push((input): unknown[] => input.filter(callback));
+    return this;
+  }
+
+  /**
+   * Map each source item to a new type.
+   *
+   * @param callback - A mapping function that takes a source item and returns
+   * corresponding mapped item.
+   *
+   * @typeparam TI - Target item type.
+   * @typeparam TP - Target item type's id property name.
+   *
+   * @returns This factory for further configuration.
+   */
+  public map<TI extends PartItem<TP>, TP extends string = "id">(
+    callback: (item: SI) => TI
+  ): DataPipeUnderConstruction<TI, TP> {
+    this._transformers.push((input): unknown[] => input.map(callback));
+    return (this as unknown) as DataPipeUnderConstruction<TI, TP>;
+  }
+
+  /**
+   * Map each source item to zero or more items of a new type.
+   *
+   * @param callback - A mapping function that takes a source item and returns
+   * an array of corresponding mapped items.
+   *
+   * @typeparam TI - Target item type.
+   * @typeparam TP - Target item type's id property name.
+   *
+   * @returns This factory for further configuration.
+   */
+  public flatMap<TI extends PartItem<TP>, TP extends string = "id">(
+    callback: (item: SI) => TI[]
+  ): DataPipeUnderConstruction<TI, TP> {
+    this._transformers.push((input): unknown[] => input.flatMap(callback));
+    return (this as unknown) as DataPipeUnderConstruction<TI, TP>;
+  }
+
+  /**
+   * Connect this pipe to given data set.
+   *
+   * @param target - The data set that will receive the items from this pipe.
+   *
+   * @returns The pipe connected between given data sets and performing
+   * configured transformation on the processed items.
+   */
+  public to(target: DataSet<SI, SP>): DataPipe {
+    return new SimpleDataPipe(this._source, this._transformers, target);
+  }
+}

--- a/src/data-set.ts
+++ b/src/data-set.ts
@@ -43,6 +43,8 @@ export interface DataSetInitialOptions<IdProp extends string> {
    *
    * @remarks
    * **Warning**: There is no TypeScript support for this.
+   *
+   * @deprecated
    */
   type?: TypeMap;
   /**
@@ -112,15 +114,6 @@ export interface DataSetOptions {
  *   }
  * });
  * console.log('filtered items', items);
- *
- * // retrieve formatted items
- * var items = data.get({
- *   fields: ['id', 'date'],
- *   type: {
- *     date: 'ISODate'
- *   }
- * });
- * console.log('formatted items', items);
  * ```
  *
  * @typeParam Item - Item type that may or may not have an id.
@@ -177,6 +170,11 @@ export class DataSet<
     // all variants of a Date are internally stored as Date, so we can convert
     // from everything to everything (also from ISODate to Number for example)
     if (this._options.type) {
+      console.warn(
+        "Type coercion has been deprecated. Please, use data pipes instead."
+      );
+      console.trace();
+
       const fields = Object.keys(this._options.type);
       for (let i = 0, len = fields.length; i < len; i++) {
         const field = fields[i];
@@ -1054,6 +1052,11 @@ export class DataSet<
     }
 
     if (fieldType) {
+      console.warn(
+        "Type coercion has been deprecated. Please, use data pipes instead."
+      );
+      console.trace();
+
       for (let i = 0, len = values.length; i < len; i++) {
         values[i] = convert(values[i], fieldType);
       }
@@ -1091,6 +1094,12 @@ export class DataSet<
     for (let i = 0, len = fields.length; i < len; i++) {
       const field = fields[i];
       const fieldType = this._type[field]; // type may be undefined
+      if (fieldType != null) {
+        console.warn(
+          "Type coercion has been deprecated. Please, use data pipes instead."
+        );
+        console.trace();
+      }
       d[field] = convert((item as any)[field], fieldType);
     }
     this._data.set(id, d);
@@ -1122,6 +1131,11 @@ export class DataSet<
     const fields = Object.keys(raw);
 
     if (types) {
+      console.warn(
+        "Type coercion has been deprecated. Please, use data pipes instead."
+      );
+      console.trace();
+
       converted = {};
       for (let i = 0, len = fields.length; i < len; i++) {
         const field = fields[i];
@@ -1168,6 +1182,12 @@ export class DataSet<
     for (let i = 0, len = fields.length; i < len; i++) {
       const field = fields[i];
       const fieldType = this._type[field]; // type may be undefined
+      if (fieldType != null) {
+        console.warn(
+          "Type coercion has been deprecated. Please, use data pipes instead."
+        );
+        console.trace();
+      }
       (d as any)[field] = convert((item as any)[field], fieldType);
     }
 

--- a/src/data-set.ts
+++ b/src/data-set.ts
@@ -28,6 +28,15 @@ import { Queue, QueueOptions } from "./queue";
 import { DataSetPart } from "./data-set-part";
 import { DataStream } from "./data-stream";
 
+const warnTypeCorectionDeprecation = (): void => {
+  console.warn(
+    "Type coercion has been deprecated. " +
+      "Please, use data pipes instead. " +
+      "See https://visjs.github.io/vis-data/data/datapipe.html#TypeCoercion for more details with working migration example."
+  );
+  console.trace();
+};
+
 /**
  * Initial DataSet configuration object.
  *
@@ -170,10 +179,7 @@ export class DataSet<
     // all variants of a Date are internally stored as Date, so we can convert
     // from everything to everything (also from ISODate to Number for example)
     if (this._options.type) {
-      console.warn(
-        "Type coercion has been deprecated. Please, use data pipes instead."
-      );
-      console.trace();
+      warnTypeCorectionDeprecation();
 
       const fields = Object.keys(this._options.type);
       for (let i = 0, len = fields.length; i < len; i++) {
@@ -1052,10 +1058,7 @@ export class DataSet<
     }
 
     if (fieldType) {
-      console.warn(
-        "Type coercion has been deprecated. Please, use data pipes instead."
-      );
-      console.trace();
+      warnTypeCorectionDeprecation();
 
       for (let i = 0, len = values.length; i < len; i++) {
         values[i] = convert(values[i], fieldType);
@@ -1095,10 +1098,7 @@ export class DataSet<
       const field = fields[i];
       const fieldType = this._type[field]; // type may be undefined
       if (fieldType != null) {
-        console.warn(
-          "Type coercion has been deprecated. Please, use data pipes instead."
-        );
-        console.trace();
+        warnTypeCorectionDeprecation();
       }
       d[field] = convert((item as any)[field], fieldType);
     }
@@ -1131,10 +1131,7 @@ export class DataSet<
     const fields = Object.keys(raw);
 
     if (types) {
-      console.warn(
-        "Type coercion has been deprecated. Please, use data pipes instead."
-      );
-      console.trace();
+      warnTypeCorectionDeprecation();
 
       converted = {};
       for (let i = 0, len = fields.length; i < len; i++) {
@@ -1183,10 +1180,7 @@ export class DataSet<
       const field = fields[i];
       const fieldType = this._type[field]; // type may be undefined
       if (fieldType != null) {
-        console.warn(
-          "Type coercion has been deprecated. Please, use data pipes instead."
-        );
-        console.trace();
+        warnTypeCorectionDeprecation();
       }
       (d as any)[field] = convert((item as any)[field], fieldType);
     }

--- a/test/data-pipe.test.ts
+++ b/test/data-pipe.test.ts
@@ -1,0 +1,206 @@
+import { expect } from "chai";
+
+import { DataSet } from "../src";
+import { DataPipe, createNewDataPipeFrom } from "../src/data-pipe";
+
+interface Item1 {
+  whoami: string;
+  enabled: boolean;
+  bar: number;
+  vis: Item2;
+}
+interface Item2 {
+  myId: number;
+  foo: string;
+  updated: string;
+}
+
+const generateItem = (index: number, updated = "no"): Item1 =>
+  Object.freeze({
+    whoami: String.fromCharCode(64 + index),
+    enabled: index % 3 !== 0,
+    bar: index,
+    vis: Object.freeze({
+      myId: index,
+      foo: String.fromCharCode(96 + index),
+      updated
+    })
+  });
+
+const skippedItem: (index: 3 | 6 | 9, updated?: string) => Item1 = generateItem;
+const pipedItem: (
+  index: 1 | 2 | 4 | 5 | 7 | 8 | 10 | 11,
+  updated?: string
+) => Item1 = generateItem;
+
+type Config = {
+  name: string;
+  expected: Item2[];
+  message: string;
+  operation(
+    ds1: DataSet<Item1, "whoami">,
+    pipe: DataPipe,
+    ds2: DataSet<Item2, "myId">
+  ): void;
+};
+
+describe("Data Pipe", function(): void {
+  describe("Filter and map", function(): void {
+    const configs: Config[] = [
+      {
+        name: "Not even started",
+        expected: [],
+        message: "No items should be added before the pipe is started",
+        operation(ds1): void {
+          ds1.add(skippedItem(6));
+          ds1.add(pipedItem(7));
+          ds1.add(pipedItem(8));
+        }
+      },
+      {
+        name: "Adding",
+        expected: [pipedItem(7).vis, pipedItem(8).vis],
+        message: "Only changes after the pipe was started should be processed",
+        operation(ds1, pipe): void {
+          pipe.start();
+          ds1.add([skippedItem(6), pipedItem(7), pipedItem(8)]);
+        }
+      },
+      {
+        name: "Updating",
+        expected: [pipedItem(1, "updated").vis, pipedItem(2, "updated").vis],
+        message: "Updated items should be created if they didn't exist before",
+        operation(ds1, pipe): void {
+          pipe.start();
+          ds1.update([
+            pipedItem(1, "updated"),
+            pipedItem(2, "updated"),
+            skippedItem(3, "updated")
+          ]);
+        }
+      },
+      {
+        name: "Removing",
+        expected: [pipedItem(8).vis],
+        message: "Updated items should be created if they didn't exist before",
+        operation(ds1, pipe, ds2): void {
+          pipe.start();
+
+          ds1.add([skippedItem(6), pipedItem(7), pipedItem(8)]);
+          expect(
+            ds2.length,
+            "Items should have been piped into the second data set by now"
+          ).to.equal(2);
+          ds1.remove([skippedItem(6), pipedItem(7)]);
+        }
+      },
+      {
+        name: "Piping all the data",
+        expected: [pipedItem(1).vis, pipedItem(2).vis, pipedItem(4).vis],
+        message: "All the data present in the source data set should be piped",
+        operation(_ds1, pipe): void {
+          pipe.all();
+        }
+      },
+      {
+        name: "Stopping",
+        expected: [pipedItem(7).vis, pipedItem(8).vis],
+        message: "All changes should be ignored if the pipe was stopped",
+        operation(ds1, pipe): void {
+          pipe.start();
+          ds1.add([skippedItem(6), pipedItem(7), pipedItem(8)]);
+
+          pipe.stop();
+          ds1.add([skippedItem(9), pipedItem(10), pipedItem(11)]);
+          ds1.update([skippedItem(6, "updated"), pipedItem(7, "updated")]);
+          ds1.remove([skippedItem(6, "updated"), pipedItem(7, "updated")]);
+        }
+      },
+      {
+        name: "All combined",
+        expected: [
+          pipedItem(2, "updated").vis,
+          pipedItem(4).vis,
+          pipedItem(5).vis,
+          pipedItem(7).vis,
+          pipedItem(10, "updated").vis
+        ],
+        message: "This should work",
+        operation(ds1, pipe): void {
+          pipe
+            .start()
+            .stop()
+            .all()
+            .start();
+          ds1.add([pipedItem(5), skippedItem(6), pipedItem(7)]);
+          ds1.remove(pipedItem(1));
+          ds1.update([pipedItem(2, "updated"), skippedItem(3, "updated")]);
+
+          pipe.stop();
+          ds1.remove([pipedItem(5), skippedItem(6), pipedItem(7)]);
+          ds1.add([pipedItem(8), skippedItem(9), pipedItem(10)]);
+
+          pipe.start();
+          ds1.update([skippedItem(9, "updated"), pipedItem(10, "updated")]);
+        }
+      }
+    ];
+
+    configs.forEach(({ expected, message, name, operation }): void => {
+      it(name, function(): void {
+        const ds1 = new DataSet<Item1, "whoami">(
+          [pipedItem(1), pipedItem(2), skippedItem(3), pipedItem(4)],
+          { fieldId: "whoami" }
+        );
+
+        const ds2 = new DataSet<Item2, "myId">([], { fieldId: "myId" });
+
+        const pipe = createNewDataPipeFrom(ds1)
+          .filter((item): boolean => item.enabled === true)
+          .map<Item2, "myId">((item): Item2 => item.vis)
+          .to(ds2);
+
+        operation(ds1, pipe, ds2);
+
+        expect(ds2.get(), message).to.deep.equal(expected);
+      });
+    });
+  });
+
+  it("FlatMap", function(): void {
+    const ds1 = new DataSet<Item1, "whoami">(
+      [pipedItem(1), pipedItem(2), skippedItem(3), pipedItem(4)],
+      { fieldId: "whoami" }
+    );
+
+    const ds2 = new DataSet<Item2, "myId">([], { fieldId: "myId" });
+
+    const pipe = createNewDataPipeFrom(ds1)
+      .flatMap<Item2, "myId">((item): Item2[] =>
+        item.vis.myId % 3 === 0
+          ? []
+          : [item.vis, { ...item.vis, myId: -item.vis.myId }]
+      )
+      .to(ds2);
+
+    pipe.all().start();
+
+    ds1.add([pipedItem(5), skippedItem(6)]);
+    ds1.update([pipedItem(2, "updated"), skippedItem(3, "updated")]);
+    ds1.remove(pipedItem(4));
+
+    expect(
+      ds2.get(),
+      "Unexpected items found, expected missing or corrupted"
+    ).to.deep.equal([
+      pipedItem(1).vis,
+      { ...pipedItem(1).vis, myId: -1 },
+
+      pipedItem(2, "updated").vis,
+      { ...pipedItem(2, "updated").vis, myId: -2 },
+
+      pipedItem(5).vis,
+      { ...pipedItem(5).vis, myId: -5 }
+    ]);
+  });
+});


### PR DESCRIPTION
This is intended mainly as a replacement for type coercion (the `type` parameter of `DataSet` constructor). An example of this is a part of the docs included in this PR. It also offers a solution to visjs/vis-network#234.

For more info about why we have to get rid of type coercion see https://github.com/orgs/visjs/teams/maintainer/discussions/3.

Advantages:
- Fully typesafe in TypeScript.
- No need to bundle Moment.js to make it work.
- Can do a lot more than just type coercion.
- After we remove type coercion the data set code will greatly simplify.

Disadvantages:
- More difficult to set up.
- Somewhat higher overhead after add/remove/update operations.

Features:
- Pipe items from a data set or data view.
- Filter items in the pipe.
- Map items in the pipe.
- FlatMap items in the pipe.
- The same operation can be used multiple times.
- Pipe the result to a data set.

Example usage:
```typescript
interface RawItem {
  id: number | string;
  label: unknown;
  color: unknown;
  x: unknown;
  y: unknown;
}
interface CoercedItem {
  id: number | string;
  label: string;
  color: string;
  x: number;
  y: number;
}

const rawDS = new DataSet<RawItem, "id">();
const coercedDS = new DataSet<CoercedItem, "id">();

const pipe = createNewDataPipeFrom(rawDS)
  // All items can be arbitrarily transformed. The original `util.convert`
  // function could be used here or more elaborate operations could be
  // performed instead.
  .map<CoercedItem, "id">(
    ({ id, label, color, x, y }): CoercedItem => ({
      id,
      label: "" + label,
      color: "" + color,
      x: +x,
      y: +y
    })
  )
  // This builds and returns the pipe from rawDS to coercedDS.
  .to(coercedDS);

pipe.all().start();
// All items were transformed and piped into coercedDS and all later changes will be
// transformed and piped as well.
```