### PR TITLE
style(eslint): update the config for new version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,6 +94,7 @@ module.exports = {
     // Reports typeof bigint as an error, tsc validates this anyway so no problem turning this off.
     'valid-typeof': 'off',
     // Why?
+    '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-parameter-properties': 'off',
   },
 }


### PR DESCRIPTION
A new rule is enforced by default, it breaks linting and I don't see any benefit in it.