### PR TITLE
feat(data-view): add dispose method

### DIFF
--- a/test/data-view-dispose.test.ts
+++ b/test/data-view-dispose.test.ts
@@ -1,0 +1,28 @@
+import { expect } from "chai";
+
+import { DataSet, DataView } from "../src";
+
+interface Item {
+  id: number;
+}
+
+describe("Data view dispose", function(): void {
+  it("Disposed data view is unsubscribed and throws", function(): void {
+    const ds = new DataSet<Item>([{ id: 1 }, { id: 2 }]);
+    const dv = new DataView(ds);
+
+    expect(ds.getIds().sort()).to.deep.equal([1, 2].sort());
+
+    ds.add({ id: 3 });
+    expect(ds.getIds().sort()).to.deep.equal([1, 2, 3].sort());
+
+    dv.dispose();
+    expect(
+      (ds as any)._subscribers["*"],
+      "Disposed data view should be unsubscribed from it's data set."
+    ).to.have.lengthOf(0);
+    expect((): void => {
+      dv.getIds();
+    }, "Disposed data view should always throw.").to.throw();
+  });
+});


### PR DESCRIPTION
When working on https://github.com/visjs/vis-timeline/pull/316 I came to the conclusion that it would be great to have some kind of dispose method for these cases. `dataView.setData(null)` technically speaking works but it creates a new data set and the instance can be used later on. It's quite counter intuitive and very error prone. The `DataView.dispose()` introduced here makes the data view throw if used after disposal immediately pointing to the fact that there's something wrong with the lifecycle of data views.