### PR TITLE
fix(deps): make peer, dev and implementation versions match

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
   },
   "peerDependencies": {
     "moment": "^2.24.0",
-    "vis-util": "^2.1.0 || ^4.0.0",
-    "uuid": "^3.4.0 || ^7.0.0"
+    "vis-util": "^4.0.0",
+    "uuid": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/src/data-set.ts
+++ b/src/data-set.ts
@@ -1,6 +1,6 @@
 /* eslint @typescript-eslint/member-ordering: ["error", { "classes": ["field", "constructor", "method"] }] */
 
-import { default as uuid4 } from "uuid/v4";
+import { v4 as uuid4 } from "uuid";
 import { convert } from "./convert";
 import { deepExtend } from "vis-util/esnext";
 


### PR DESCRIPTION
Vis Util bellow 4.0.0 would not work at all.
Vis UUID 7.0.0+ would show deprecation warnings.

Closes #175.