### PR TITLE
chore(confs): remove forgotten config file

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: ['@commitlint/config-conventional'],
-}


### PR DESCRIPTION
We don't have commit lint here, it's pointless to have a configuration for it.