### PR TITLE
feat(data-set): add DELETE symbol to delete props through updateOnly

### DIFF
--- a/src/data-interface.ts
+++ b/src/data-interface.ts
@@ -1,3 +1,4 @@
+import { Assignable } from "vis-util/esnext";
 import { DataSet } from "./data-set";
 import { DataStream } from "./data-stream";
 
@@ -77,7 +78,7 @@ export type FullItem<
 export type UpdateItem<
   Item extends PartItem<IdProp>,
   IdProp extends string
-> = DeepPartial<Item> & Record<IdProp, Id>;
+> = Assignable<FullItem<Item, IdProp>> & Record<IdProp, Id>;
 
 /**
  * Test whether an item has an id (is a [[FullItem]]).

--- a/src/data-set.ts
+++ b/src/data-set.ts
@@ -2,7 +2,7 @@
 
 import { v4 as uuid4 } from "uuid";
 import { convert } from "./convert";
-import { deepExtend } from "vis-util/esnext";
+import { pureDeepObjectAssign } from "vis-util/esnext";
 
 import {
   DataInterface,
@@ -447,7 +447,7 @@ export class DataSet<
         updatedData: FullItem<Item, IdProp>;
       } => {
         const id = oldData[this._idProp];
-        const updatedData = deepExtend(deepExtend({}, oldData), update);
+        const updatedData = pureDeepObjectAssign(oldData, update);
 
         this._data.set(id, updatedData);
 

--- a/src/entry-esnext.ts
+++ b/src/entry-esnext.ts
@@ -19,3 +19,4 @@ export { DataSet, DataSetOptions } from "./data-set";
 export { DataStream } from "./data-stream";
 export { DataView, DataViewOptions } from "./data-view";
 export { Queue } from "./queue";
+export { DELETE } from "vis-util/esnext";

--- a/test/data-set.test.ts
+++ b/test/data-set.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import { DataSet } from "../src";
+import { DELETE, DataSet } from "../src";
 
 interface Item1 {
   whoami: number;
@@ -12,6 +12,14 @@ interface Item2 {
   payload: {
     foo: string;
     bar: boolean;
+  };
+}
+interface Item3 {
+  whoami: number;
+  payload?: {
+    p1?: string;
+    p2?: number;
+    p3?: boolean;
   };
 }
 
@@ -209,6 +217,33 @@ describe("Data Set", function (): void {
         ds.get(8),
         "Update should not modify the item in place (a new object should be created)."
       ).to.not.equal(originalItem8);
+    });
+
+    it("Delete props through updateOnly", function (): void {
+      const ds = new DataSet<Item3, "whoami">(
+        [{ whoami: 7, payload: { p1: "7", p2: 7, p3: true } }],
+        { fieldId: "whoami" }
+      );
+
+      ds.updateOnly({ whoami: 7, payload: { p1: DELETE } });
+      expect(ds.get(7), "DELETE should delete properties").to.deep.equal({
+        whoami: 7,
+        payload: {
+          p2: 7,
+          p3: true,
+        },
+      });
+
+      ds.updateOnly({ whoami: 7, payload: { p2: DELETE, p3: DELETE } });
+      expect(ds.get(7), "DELETE should delete properties").to.deep.equal({
+        whoami: 7,
+        payload: {},
+      });
+
+      ds.updateOnly({ whoami: 7, payload: DELETE });
+      expect(ds.get(7), "DELETE should delete properties").to.deep.equal({
+        whoami: 7,
+      });
     });
   });
 


### PR DESCRIPTION
It's as simple as that.

I didn't find any breaking changes, all the old tests still pass, so minor release should be appropriate.

Close https://github.com/visjs/vis-network/issues/739.