### PR TITLE
fix: use #props instead of underscore convention

### DIFF
--- a/src/data-pipe.ts
+++ b/src/data-pipe.ts
@@ -219,7 +219,7 @@ class DataPipeUnderConstruction<
    * Array transformers used to transform items within the pipe. This is typed
    * as any for the sake of simplicity.
    */
-  private readonly _transformers: Transformer<any>[] = [];
+  readonly #transformers: Transformer<any>[] = [];
 
   /**
    * Create a new data pipe factory. This is an internal constructor that
@@ -240,7 +240,7 @@ class DataPipeUnderConstruction<
   public filter(
     callback: (item: SI) => boolean
   ): DataPipeUnderConstruction<SI, SP> {
-    this._transformers.push((input): unknown[] => input.filter(callback));
+    this.#transformers.push((input): unknown[] => input.filter(callback));
     return this;
   }
 
@@ -258,7 +258,7 @@ class DataPipeUnderConstruction<
   public map<TI extends PartItem<TP>, TP extends string = "id">(
     callback: (item: SI) => TI
   ): DataPipeUnderConstruction<TI, TP> {
-    this._transformers.push((input): unknown[] => input.map(callback));
+    this.#transformers.push((input): unknown[] => input.map(callback));
     return (this as unknown) as DataPipeUnderConstruction<TI, TP>;
   }
 
@@ -276,7 +276,7 @@ class DataPipeUnderConstruction<
   public flatMap<TI extends PartItem<TP>, TP extends string = "id">(
     callback: (item: SI) => TI[]
   ): DataPipeUnderConstruction<TI, TP> {
-    this._transformers.push((input): unknown[] => input.flatMap(callback));
+    this.#transformers.push((input): unknown[] => input.flatMap(callback));
     return (this as unknown) as DataPipeUnderConstruction<TI, TP>;
   }
 
@@ -289,6 +289,6 @@ class DataPipeUnderConstruction<
    * configured transformation on the processed items.
    */
   public to(target: DataSet<SI, SP>): DataPipe {
-    return new SimpleDataPipe(this._source, this._transformers, target);
+    return new SimpleDataPipe(this._source, this.#transformers, target);
   }
 }

--- a/src/data-set-part.ts
+++ b/src/data-set-part.ts
@@ -19,7 +19,7 @@ type EventSubscribers<Item, IdProp extends string> = {
  */
 export abstract class DataSetPart<Item, IdProp extends string>
   implements Pick<DataInterface<Item, IdProp>, "on" | "off"> {
-  protected _subscribers: {
+  #subscribers: {
     [Name in EventNameWithAny]: EventSubscribers<Item, IdProp>[Name][];
   } = {
     "*": [],
@@ -59,7 +59,7 @@ export abstract class DataSetPart<Item, IdProp extends string>
       throw new Error("Cannot trigger event *");
     }
 
-    [...this._subscribers[event], ...this._subscribers["*"]].forEach(
+    [...this.#subscribers[event], ...this.#subscribers["*"]].forEach(
       (subscriber): void => {
         subscriber(event, payload, senderId != null ? senderId : null);
       }
@@ -99,7 +99,7 @@ export abstract class DataSetPart<Item, IdProp extends string>
     callback: EventCallbacksWithAny<Item, IdProp>[Name]
   ): void {
     if (typeof callback === "function") {
-      this._subscribers[event].push(callback);
+      this.#subscribers[event].push(callback);
     }
     // @TODO: Maybe throw for invalid callbacks?
   }
@@ -136,7 +136,7 @@ export abstract class DataSetPart<Item, IdProp extends string>
     event: Name,
     callback: EventCallbacksWithAny<Item, IdProp>[Name]
   ): void {
-    this._subscribers[event] = this._subscribers[event].filter(
+    this.#subscribers[event] = this.#subscribers[event].filter(
       (subscriber): boolean => subscriber !== callback
     );
   }
@@ -150,4 +150,10 @@ export abstract class DataSetPart<Item, IdProp extends string>
    */
   public unsubscribe: DataSetPart<Item, IdProp>["off"] =
     DataSetPart.prototype.off;
+
+  /* develblock:start */
+  public get testLeakSubscribers(): any {
+    return this.#subscribers;
+  }
+  /* develblock:end */
 }

--- a/src/data-stream.ts
+++ b/src/data-stream.ts
@@ -11,18 +11,22 @@ import { Id } from "./data-interface";
  * @typeParam Item - The item type this stream is going to work with.
  */
 export class DataStream<Item> implements Iterable<[Id, Item]> {
+  readonly #pairs: Iterable<[Id, Item]>;
+
   /**
    * Create a new data stream.
    *
-   * @param _pairs - The id, item pairs.
+   * @param pairs - The id, item pairs.
    */
-  public constructor(private readonly _pairs: Iterable<[Id, Item]>) {}
+  public constructor(pairs: Iterable<[Id, Item]>) {
+    this.#pairs = pairs;
+  }
 
   /**
    * Return an iterable of key, value pairs for every entry in the stream.
    */
   public *[Symbol.iterator](): IterableIterator<[Id, Item]> {
-    for (const [id, item] of this._pairs) {
+    for (const [id, item] of this.#pairs) {
       yield [id, item];
     }
   }
@@ -31,7 +35,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * Return an iterable of key, value pairs for every entry in the stream.
    */
   public *entries(): IterableIterator<[Id, Item]> {
-    for (const [id, item] of this._pairs) {
+    for (const [id, item] of this.#pairs) {
       yield [id, item];
     }
   }
@@ -40,7 +44,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * Return an iterable of keys in the stream.
    */
   public *keys(): IterableIterator<Id> {
-    for (const [id] of this._pairs) {
+    for (const [id] of this.#pairs) {
       yield id;
     }
   }
@@ -49,7 +53,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * Return an iterable of values in the stream.
    */
   public *values(): IterableIterator<Item> {
-    for (const [, item] of this._pairs) {
+    for (const [, item] of this.#pairs) {
       yield item;
     }
   }
@@ -63,7 +67,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns The array with all ids from this stream.
    */
   public toIdArray(): Id[] {
-    return [...this._pairs].map((pair): Id => pair[0]);
+    return [...this.#pairs].map((pair): Id => pair[0]);
   }
 
   /**
@@ -75,7 +79,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns The array with all items from this stream.
    */
   public toItemArray(): Item[] {
-    return [...this._pairs].map((pair): Item => pair[1]);
+    return [...this.#pairs].map((pair): Item => pair[1]);
   }
 
   /**
@@ -87,7 +91,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns The array with all entries from this stream.
    */
   public toEntryArray(): [Id, Item][] {
-    return [...this._pairs];
+    return [...this.#pairs];
   }
 
   /**
@@ -100,7 +104,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    */
   public toObjectMap(): Record<Id, Item> {
     const map: Record<Id, Item> = Object.create(null);
-    for (const [id, item] of this._pairs) {
+    for (const [id, item] of this.#pairs) {
       map[id] = item;
     }
     return map;
@@ -112,7 +116,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns The map of all id → item pairs from this stream.
    */
   public toMap(): Map<Id, Item> {
-    return new Map(this._pairs);
+    return new Map(this.#pairs);
   }
 
   /**
@@ -157,7 +161,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns A new [[DataStream]] with cached items (detached from the original [[DataSet]]).
    */
   public cache(): DataStream<Item> {
-    return new DataStream([...this._pairs]);
+    return new DataStream([...this.#pairs]);
   }
 
   /**
@@ -172,7 +176,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
   public distinct<T>(callback: (item: Item, id: Id) => T): Set<T> {
     const set = new Set<T>();
 
-    for (const [id, item] of this._pairs) {
+    for (const [id, item] of this.#pairs) {
       set.add(callback(item, id));
     }
 
@@ -187,7 +191,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns A new data stream with the filtered items.
    */
   public filter(callback: (item: Item, id: Id) => boolean): DataStream<Item> {
-    const pairs = this._pairs;
+    const pairs = this.#pairs;
     return new DataStream<Item>({
       *[Symbol.iterator](): IterableIterator<[Id, Item]> {
         for (const [id, item] of pairs) {
@@ -205,7 +209,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @param callback - The function that will be invoked for each item.
    */
   public forEach(callback: (item: Item, id: Id) => boolean): void {
-    for (const [id, item] of this._pairs) {
+    for (const [id, item] of this.#pairs) {
       callback(item, id);
     }
   }
@@ -222,7 +226,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
   public map<Mapped>(
     callback: (item: Item, id: Id) => Mapped
   ): DataStream<Mapped> {
-    const pairs = this._pairs;
+    const pairs = this.#pairs;
     return new DataStream<Mapped>({
       *[Symbol.iterator](): IterableIterator<[Id, Mapped]> {
         for (const [id, item] of pairs) {
@@ -240,7 +244,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns The item with the maximum if found otherwise null.
    */
   public max(callback: (item: Item, id: Id) => number): Item | null {
-    const iter = this._pairs[Symbol.iterator]();
+    const iter = this.#pairs[Symbol.iterator]();
     let curr = iter.next();
     if (curr.done) {
       return null;
@@ -268,7 +272,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns The item with the minimum if found otherwise null.
    */
   public min(callback: (item: Item, id: Id) => number): Item | null {
-    const iter = this._pairs[Symbol.iterator]();
+    const iter = this.#pairs[Symbol.iterator]();
     let curr = iter.next();
     if (curr.done) {
       return null;
@@ -302,7 +306,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
     callback: (accumulator: T, item: Item, id: Id) => T,
     accumulator: T
   ): T {
-    for (const [id, item] of this._pairs) {
+    for (const [id, item] of this.#pairs) {
       accumulator = callback(accumulator, item, id);
     }
     return accumulator;
@@ -320,7 +324,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
   ): DataStream<Item> {
     return new DataStream({
       [Symbol.iterator]: (): IterableIterator<[Id, Item]> =>
-        [...this._pairs]
+        [...this.#pairs]
           .sort(([idA, itemA], [idB, itemB]): number =>
             callback(itemA, itemB, idA, idB)
           )

--- a/src/entry-esnext.ts
+++ b/src/entry-esnext.ts
@@ -1,3 +1,7 @@
+/* develblock:start */
+console.warn("You're running a development build.");
+/* develblock:end */
+
 export {
   DataInterface,
   DataInterfaceGetIdsOptions,

--- a/test/DataSet.test.js
+++ b/test/DataSet.test.js
@@ -387,29 +387,29 @@ describe("DataSet", function () {
     it("does not update queue when passed an undefined queue", function () {
       var dataset = new DataSet([], { queue: true });
       dataset.setOptions({ queue: undefined });
-      assert.notEqual(dataset._queue, undefined);
+      assert.notEqual(dataset.testLeakQueue, undefined);
     });
 
     it("destroys the queue when queue set to false", function () {
       var dataset = new DataSet([]);
       dataset.setOptions({ queue: false });
-      assert.equal(dataset._queue, undefined);
+      assert.equal(dataset.testLeakQueue, undefined);
     });
 
     it("udpates queue options", function () {
       var dataset = new DataSet([]);
       dataset.setOptions({ queue: { max: 5, delay: 3 } });
-      assert.equal(dataset._queue.max, 5);
-      assert.equal(dataset._queue.delay, 3);
+      assert.equal(dataset.testLeakQueue.max, 5);
+      assert.equal(dataset.testLeakQueue.delay, 3);
     });
 
     it("creates new queue given if none is set", function () {
       var dataset = new DataSet([], { queue: true });
-      dataset._queue.destroy();
-      dataset._queue = null;
+      dataset.testLeakQueue.destroy();
+      dataset.testLeakQueue = null;
       dataset.setOptions({ queue: { max: 5, delay: 3 } });
-      assert.equal(dataset._queue.max, 5);
-      assert.equal(dataset._queue.delay, 3);
+      assert.equal(dataset.testLeakQueue.max, 5);
+      assert.equal(dataset.testLeakQueue.delay, 3);
     });
   });
 

--- a/test/data-view-dispose.test.ts
+++ b/test/data-view-dispose.test.ts
@@ -18,7 +18,7 @@ describe("Data view dispose", function (): void {
 
     dv.dispose();
     expect(
-      (ds as any)._subscribers["*"],
+      ds.testLeakSubscribers["*"],
       "Disposed data view should be unsubscribed from it's data set."
     ).to.have.lengthOf(0);
     expect((): void => {


### PR DESCRIPTION
This should solve issues with Vue/Angular reactivity replacing everything by observers and messing things up (implementing this in the other libraries may be necessary to completely tackle this though). However to fully prevent these issues similar changes may be necessary in Vis Network (I don't know if these problems also plague Timeline and Graph3D).

Some properties will disappear but these are undocumented and prefixed with underscore, therefore I don't consider this to be a breaking change.