### PR TITLE
fix(build): switch back to soft privacy

### DIFF
--- a/src/data-pipe.ts
+++ b/src/data-pipe.ts
@@ -219,7 +219,7 @@ class DataPipeUnderConstruction<
    * Array transformers used to transform items within the pipe. This is typed
    * as any for the sake of simplicity.
    */
-  readonly #transformers: Transformer<any>[] = [];
+  private readonly _transformers: Transformer<any>[] = [];
 
   /**
    * Create a new data pipe factory. This is an internal constructor that
@@ -240,7 +240,7 @@ class DataPipeUnderConstruction<
   public filter(
     callback: (item: SI) => boolean
   ): DataPipeUnderConstruction<SI, SP> {
-    this.#transformers.push((input): unknown[] => input.filter(callback));
+    this._transformers.push((input): unknown[] => input.filter(callback));
     return this;
   }
 
@@ -258,7 +258,7 @@ class DataPipeUnderConstruction<
   public map<TI extends PartItem<TP>, TP extends string = "id">(
     callback: (item: SI) => TI
   ): DataPipeUnderConstruction<TI, TP> {
-    this.#transformers.push((input): unknown[] => input.map(callback));
+    this._transformers.push((input): unknown[] => input.map(callback));
     return (this as unknown) as DataPipeUnderConstruction<TI, TP>;
   }
 
@@ -276,7 +276,7 @@ class DataPipeUnderConstruction<
   public flatMap<TI extends PartItem<TP>, TP extends string = "id">(
     callback: (item: SI) => TI[]
   ): DataPipeUnderConstruction<TI, TP> {
-    this.#transformers.push((input): unknown[] => input.flatMap(callback));
+    this._transformers.push((input): unknown[] => input.flatMap(callback));
     return (this as unknown) as DataPipeUnderConstruction<TI, TP>;
   }
 
@@ -289,6 +289,6 @@ class DataPipeUnderConstruction<
    * configured transformation on the processed items.
    */
   public to(target: DataSet<SI, SP>): DataPipe {
-    return new SimpleDataPipe(this._source, this.#transformers, target);
+    return new SimpleDataPipe(this._source, this._transformers, target);
   }
 }

--- a/src/data-set-part.ts
+++ b/src/data-set-part.ts
@@ -19,7 +19,7 @@ type EventSubscribers<Item, IdProp extends string> = {
  */
 export abstract class DataSetPart<Item, IdProp extends string>
   implements Pick<DataInterface<Item, IdProp>, "on" | "off"> {
-  #subscribers: {
+  private readonly _subscribers: {
     [Name in EventNameWithAny]: EventSubscribers<Item, IdProp>[Name][];
   } = {
     "*": [],
@@ -59,7 +59,7 @@ export abstract class DataSetPart<Item, IdProp extends string>
       throw new Error("Cannot trigger event *");
     }
 
-    [...this.#subscribers[event], ...this.#subscribers["*"]].forEach(
+    [...this._subscribers[event], ...this._subscribers["*"]].forEach(
       (subscriber): void => {
         subscriber(event, payload, senderId != null ? senderId : null);
       }
@@ -99,7 +99,7 @@ export abstract class DataSetPart<Item, IdProp extends string>
     callback: EventCallbacksWithAny<Item, IdProp>[Name]
   ): void {
     if (typeof callback === "function") {
-      this.#subscribers[event].push(callback);
+      this._subscribers[event].push(callback);
     }
     // @TODO: Maybe throw for invalid callbacks?
   }
@@ -136,7 +136,7 @@ export abstract class DataSetPart<Item, IdProp extends string>
     event: Name,
     callback: EventCallbacksWithAny<Item, IdProp>[Name]
   ): void {
-    this.#subscribers[event] = this.#subscribers[event].filter(
+    this._subscribers[event] = this._subscribers[event].filter(
       (subscriber): boolean => subscriber !== callback
     );
   }
@@ -153,7 +153,7 @@ export abstract class DataSetPart<Item, IdProp extends string>
 
   /* develblock:start */
   public get testLeakSubscribers(): any {
-    return this.#subscribers;
+    return this._subscribers;
   }
   /* develblock:end */
 }

--- a/src/data-set.ts
+++ b/src/data-set.ts
@@ -149,13 +149,13 @@ export class DataSet<
   public length: number;
   /** @inheritDoc */
   public get idProp(): IdProp {
-    return this.#idProp;
+    return this._idProp;
   }
 
-  readonly #options: DataSetInitialOptions<IdProp>;
-  readonly #data: Map<Id, FullItem<Item, IdProp>>;
-  readonly #idProp: IdProp;
-  #queue: Queue<this> | null = null;
+  private readonly _options: DataSetInitialOptions<IdProp>;
+  private readonly _data: Map<Id, FullItem<Item, IdProp>>;
+  private readonly _idProp: IdProp;
+  private _queue: Queue<this> | null = null;
 
   /**
    * @param options - DataSet configuration.
@@ -184,10 +184,10 @@ export class DataSet<
       data = [];
     }
 
-    this.#options = options || {};
-    this.#data = new Map(); // map with data indexed by id
+    this._options = options || {};
+    this._data = new Map(); // map with data indexed by id
     this.length = 0; // number of items in the DataSet
-    this.#idProp = this.#options.fieldId || ("id" as IdProp); // name of the field containing id
+    this._idProp = this._options.fieldId || ("id" as IdProp); // name of the field containing id
 
     // add initial data when provided
     if (data && data.length) {
@@ -206,20 +206,20 @@ export class DataSet<
     if (options && options.queue !== undefined) {
       if (options.queue === false) {
         // delete queue if loaded
-        if (this.#queue) {
-          this.#queue.destroy();
-          this.#queue = null;
+        if (this._queue) {
+          this._queue.destroy();
+          this._queue = null;
         }
       } else {
         // create queue and update its options
-        if (!this.#queue) {
-          this.#queue = Queue.extend(this, {
+        if (!this._queue) {
+          this._queue = Queue.extend(this, {
             replace: ["add", "update", "remove"],
           });
         }
 
         if (options.queue && typeof options.queue === "object") {
-          this.#queue.setOptions(options.queue);
+          this._queue.setOptions(options.queue);
         }
       }
     }
@@ -259,8 +259,8 @@ export class DataSet<
 
     if (Array.isArray(data)) {
       // Array
-      const idsToAdd: Id[] = data.map((d) => d[this.#idProp] as Id);
-      if (idsToAdd.some((id) => this.#data.has(id))) {
+      const idsToAdd: Id[] = data.map((d) => d[this._idProp] as Id);
+      if (idsToAdd.some((id) => this._data.has(id))) {
         throw new Error("A duplicate id was found in the parameter array.");
       }
       for (let i = 0, len = data.length; i < len; i++) {
@@ -327,13 +327,13 @@ export class DataSet<
     const updatedIds: Id[] = [];
     const oldData: FullItem<Item, IdProp>[] = [];
     const updatedData: FullItem<Item, IdProp>[] = [];
-    const idProp = this.#idProp;
+    const idProp = this._idProp;
 
     const addOrUpdate = (item: DeepPartial<Item>): void => {
       const origId: OptId = item[idProp];
-      if (origId != null && this.#data.has(origId)) {
+      if (origId != null && this._data.has(origId)) {
         const fullItem = item as FullItem<Item, IdProp>; // it has an id, therefore it is a fullitem
-        const oldItem = Object.assign({}, this.#data.get(origId));
+        const oldItem = Object.assign({}, this._data.get(origId));
         // update item
         const id = this._updateItem(fullItem);
         updatedIds.push(id);
@@ -432,7 +432,7 @@ export class DataSet<
         oldData: FullItem<Item, IdProp>;
         update: UpdateItem<Item, IdProp>;
       } => {
-        const oldData = this.#data.get(update[this.#idProp]);
+        const oldData = this._data.get(update[this._idProp]);
         if (oldData == null) {
           throw new Error("Updating non-existent items is not allowed.");
         }
@@ -443,10 +443,10 @@ export class DataSet<
         oldData: FullItem<Item, IdProp>;
         updatedData: FullItem<Item, IdProp>;
       } => {
-        const id = oldData[this.#idProp];
+        const id = oldData[this._idProp];
         const updatedData = pureDeepObjectAssign(oldData, update);
 
-        this.#data.set(id, updatedData);
+        this._data.set(id, updatedData);
 
         return {
           id,
@@ -591,24 +591,24 @@ export class DataSet<
     // convert items
     if (id != null) {
       // return a single item
-      item = this.#data.get(id);
+      item = this._data.get(id);
       if (item && filter && !filter(item)) {
         item = undefined;
       }
     } else if (ids != null) {
       // return a subset of items
       for (let i = 0, len = ids.length; i < len; i++) {
-        item = this.#data.get(ids[i]);
+        item = this._data.get(ids[i]);
         if (item != null && (!filter || filter(item))) {
           items.push(item);
         }
       }
     } else {
       // return all items
-      itemIds = [...this.#data.keys()];
+      itemIds = [...this._data.keys()];
       for (let i = 0, len = itemIds.length; i < len; i++) {
         itemId = itemIds[i];
-        item = this.#data.get(itemId);
+        item = this._data.get(itemId);
         if (item != null && (!filter || filter(item))) {
           items.push(item);
         }
@@ -642,7 +642,7 @@ export class DataSet<
         const resultant = items[i];
         // @TODO: Shoudn't this be this._fieldId?
         // result[resultant.id] = resultant
-        const id: Id = resultant[this.#idProp];
+        const id: Id = resultant[this._idProp];
         result[id] = resultant;
       }
       return result;
@@ -659,7 +659,7 @@ export class DataSet<
 
   /** @inheritDoc */
   public getIds(options?: DataInterfaceGetIdsOptions<Item>): Id[] {
-    const data = this.#data;
+    const data = this._data;
     const filter = options && options.filter;
     const order = options && options.order;
     const itemIds = [...data.keys()];
@@ -672,7 +672,7 @@ export class DataSet<
         const items = [];
         for (let i = 0, len = itemIds.length; i < len; i++) {
           const id = itemIds[i];
-          const item = this.#data.get(id);
+          const item = this._data.get(id);
           if (item != null && filter(item)) {
             items.push(item);
           }
@@ -681,15 +681,15 @@ export class DataSet<
         this._sort(items, order);
 
         for (let i = 0, len = items.length; i < len; i++) {
-          ids.push(items[i][this.#idProp]);
+          ids.push(items[i][this._idProp]);
         }
       } else {
         // create unordered list
         for (let i = 0, len = itemIds.length; i < len; i++) {
           const id = itemIds[i];
-          const item = this.#data.get(id);
+          const item = this._data.get(id);
           if (item != null && filter(item)) {
-            ids.push(item[this.#idProp]);
+            ids.push(item[this._idProp]);
           }
         }
       }
@@ -706,7 +706,7 @@ export class DataSet<
         this._sort(items, order);
 
         for (let i = 0, len = items.length; i < len; i++) {
-          ids.push(items[i][this.#idProp]);
+          ids.push(items[i][this._idProp]);
         }
       } else {
         // create unordered list
@@ -714,7 +714,7 @@ export class DataSet<
           const id = itemIds[i];
           const item = data.get(id);
           if (item != null) {
-            ids.push(item[this.#idProp]);
+            ids.push(item[this._idProp]);
           }
         }
       }
@@ -734,7 +734,7 @@ export class DataSet<
     options?: DataInterfaceForEachOptions<Item>
   ): void {
     const filter = options && options.filter;
-    const data = this.#data;
+    const data = this._data;
     const itemIds = [...data.keys()];
 
     if (options && options.order) {
@@ -743,14 +743,14 @@ export class DataSet<
 
       for (let i = 0, len = items.length; i < len; i++) {
         const item = items[i];
-        const id = item[this.#idProp];
+        const id = item[this._idProp];
         callback(item, id);
       }
     } else {
       // unordered
       for (let i = 0, len = itemIds.length; i < len; i++) {
         const id = itemIds[i];
-        const item = this.#data.get(id);
+        const item = this._data.get(id);
         if (item != null && (!filter || filter(item))) {
           callback(item, id);
         }
@@ -765,13 +765,13 @@ export class DataSet<
   ): T[] {
     const filter = options && options.filter;
     const mappedItems: T[] = [];
-    const data = this.#data;
+    const data = this._data;
     const itemIds = [...data.keys()];
 
     // convert and filter items
     for (let i = 0, len = itemIds.length; i < len; i++) {
       const id = itemIds[i];
-      const item = this.#data.get(id);
+      const item = this._data.get(id);
       if (item != null && (!filter || filter(item))) {
         mappedItems.push(callback(item, id));
       }
@@ -892,7 +892,7 @@ export class DataSet<
     for (let i = 0, len = ids.length; i < len; i++) {
       const item = this._remove(ids[i]);
       if (item) {
-        const itemId: OptId = item[this.#idProp];
+        const itemId: OptId = item[this._idProp];
         if (itemId != null) {
           removedIds.push(itemId);
           removedItems.push(item);
@@ -927,13 +927,13 @@ export class DataSet<
     if (isId(id)) {
       ident = id;
     } else if (id && typeof id === "object") {
-      ident = id[this.#idProp]; // look for the identifier field using ._idProp
+      ident = id[this._idProp]; // look for the identifier field using ._idProp
     }
 
     // do the removing if the item is found
-    if (ident != null && this.#data.has(ident)) {
-      const item = this.#data.get(ident) || null;
-      this.#data.delete(ident);
+    if (ident != null && this._data.has(ident)) {
+      const item = this._data.get(ident) || null;
+      this._data.delete(ident);
       --this.length;
       return item;
     }
@@ -951,14 +951,14 @@ export class DataSet<
    * @returns removedIds - The ids of all removed items.
    */
   public clear(senderId?: Id | null): Id[] {
-    const ids = [...this.#data.keys()];
+    const ids = [...this._data.keys()];
     const items: FullItem<Item, IdProp>[] = [];
 
     for (let i = 0, len = ids.length; i < len; i++) {
-      items.push(this.#data.get(ids[i])!);
+      items.push(this._data.get(ids[i])!);
     }
 
-    this.#data.clear();
+    this._data.clear();
     this.length = 0;
 
     this._trigger("remove", { items: ids, oldData: items }, senderId);
@@ -977,7 +977,7 @@ export class DataSet<
     let max = null;
     let maxField = null;
 
-    for (const item of this.#data.values()) {
+    for (const item of this._data.values()) {
       const itemField = item[field];
       if (
         typeof itemField === "number" &&
@@ -1002,7 +1002,7 @@ export class DataSet<
     let min = null;
     let minField = null;
 
-    for (const item of this.#data.values()) {
+    for (const item of this._data.values()) {
       const itemField = item[field];
       if (
         typeof itemField === "number" &&
@@ -1026,7 +1026,7 @@ export class DataSet<
    * @returns Unordered array containing all distinct values. Items without specified property are ignored.
    */
   public distinct<T extends string>(prop: T): unknown[] {
-    const data = this.#data;
+    const data = this._data;
     const itemIds = [...data.keys()];
     const values: unknown[] = [];
     let count = 0;
@@ -1059,18 +1059,18 @@ export class DataSet<
    * @returns Added item's id. An id is generated when it is not present in the item.
    */
   private _addItem(item: Item): Id {
-    const fullItem = ensureFullItem(item, this.#idProp);
-    const id = fullItem[this.#idProp];
+    const fullItem = ensureFullItem(item, this._idProp);
+    const id = fullItem[this._idProp];
 
     // check whether this id is already taken
-    if (this.#data.has(id)) {
+    if (this._data.has(id)) {
       // item already exists
       throw new Error(
         "Cannot add item: item with id " + id + " already exists"
       );
     }
 
-    this.#data.set(id, fullItem);
+    this._data.set(id, fullItem);
     ++this.length;
 
     return id;
@@ -1085,7 +1085,7 @@ export class DataSet<
    * @returns The id of the updated item.
    */
   private _updateItem(update: FullItem<Item, IdProp>): Id {
-    const id: OptId = update[this.#idProp];
+    const id: OptId = update[this._idProp];
     if (id == null) {
       throw new Error(
         "Cannot update item: item has no id (item: " +
@@ -1093,13 +1093,13 @@ export class DataSet<
           ")"
       );
     }
-    const item = this.#data.get(id);
+    const item = this._data.get(id);
     if (!item) {
       // item doesn't exist
       throw new Error("Cannot update item: no item with id " + id + " found");
     }
 
-    this.#data.set(id, { ...item, ...update });
+    this._data.set(id, { ...item, ...update });
 
     return id;
   }
@@ -1107,7 +1107,7 @@ export class DataSet<
   /** @inheritDoc */
   public stream(ids?: Iterable<Id>): DataStream<Item> {
     if (ids) {
-      const data = this.#data;
+      const data = this._data;
 
       return new DataStream<Item>({
         *[Symbol.iterator](): IterableIterator<[Id, Item]> {
@@ -1121,26 +1121,26 @@ export class DataSet<
       });
     } else {
       return new DataStream({
-        [Symbol.iterator]: this.#data.entries.bind(this.#data),
+        [Symbol.iterator]: this._data.entries.bind(this._data),
       });
     }
   }
 
   /* develblock:start */
   public get testLeakData(): Map<Id, FullItem<Item, IdProp>> {
-    return this.#data;
+    return this._data;
   }
   public get testLeakIdProp(): IdProp {
-    return this.#idProp;
+    return this._idProp;
   }
   public get testLeakOptions(): DataSetInitialOptions<IdProp> {
-    return this.#options;
+    return this._options;
   }
   public get testLeakQueue(): Queue<this> | null {
-    return this.#queue;
+    return this._queue;
   }
   public set testLeakQueue(v: Queue<this> | null) {
-    this.#queue = v;
+    this._queue = v;
   }
   /* develblock:end */
 }

--- a/src/data-stream.ts
+++ b/src/data-stream.ts
@@ -11,7 +11,7 @@ import { Id } from "./data-interface";
  * @typeParam Item - The item type this stream is going to work with.
  */
 export class DataStream<Item> implements Iterable<[Id, Item]> {
-  readonly #pairs: Iterable<[Id, Item]>;
+  private readonly _pairs: Iterable<[Id, Item]>;
 
   /**
    * Create a new data stream.
@@ -19,14 +19,14 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @param pairs - The id, item pairs.
    */
   public constructor(pairs: Iterable<[Id, Item]>) {
-    this.#pairs = pairs;
+    this._pairs = pairs;
   }
 
   /**
    * Return an iterable of key, value pairs for every entry in the stream.
    */
   public *[Symbol.iterator](): IterableIterator<[Id, Item]> {
-    for (const [id, item] of this.#pairs) {
+    for (const [id, item] of this._pairs) {
       yield [id, item];
     }
   }
@@ -35,7 +35,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * Return an iterable of key, value pairs for every entry in the stream.
    */
   public *entries(): IterableIterator<[Id, Item]> {
-    for (const [id, item] of this.#pairs) {
+    for (const [id, item] of this._pairs) {
       yield [id, item];
     }
   }
@@ -44,7 +44,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * Return an iterable of keys in the stream.
    */
   public *keys(): IterableIterator<Id> {
-    for (const [id] of this.#pairs) {
+    for (const [id] of this._pairs) {
       yield id;
     }
   }
@@ -53,7 +53,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * Return an iterable of values in the stream.
    */
   public *values(): IterableIterator<Item> {
-    for (const [, item] of this.#pairs) {
+    for (const [, item] of this._pairs) {
       yield item;
     }
   }
@@ -67,7 +67,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns The array with all ids from this stream.
    */
   public toIdArray(): Id[] {
-    return [...this.#pairs].map((pair): Id => pair[0]);
+    return [...this._pairs].map((pair): Id => pair[0]);
   }
 
   /**
@@ -79,7 +79,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns The array with all items from this stream.
    */
   public toItemArray(): Item[] {
-    return [...this.#pairs].map((pair): Item => pair[1]);
+    return [...this._pairs].map((pair): Item => pair[1]);
   }
 
   /**
@@ -91,7 +91,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns The array with all entries from this stream.
    */
   public toEntryArray(): [Id, Item][] {
-    return [...this.#pairs];
+    return [...this._pairs];
   }
 
   /**
@@ -104,7 +104,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    */
   public toObjectMap(): Record<Id, Item> {
     const map: Record<Id, Item> = Object.create(null);
-    for (const [id, item] of this.#pairs) {
+    for (const [id, item] of this._pairs) {
       map[id] = item;
     }
     return map;
@@ -116,7 +116,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns The map of all id → item pairs from this stream.
    */
   public toMap(): Map<Id, Item> {
-    return new Map(this.#pairs);
+    return new Map(this._pairs);
   }
 
   /**
@@ -161,7 +161,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns A new [[DataStream]] with cached items (detached from the original [[DataSet]]).
    */
   public cache(): DataStream<Item> {
-    return new DataStream([...this.#pairs]);
+    return new DataStream([...this._pairs]);
   }
 
   /**
@@ -176,7 +176,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
   public distinct<T>(callback: (item: Item, id: Id) => T): Set<T> {
     const set = new Set<T>();
 
-    for (const [id, item] of this.#pairs) {
+    for (const [id, item] of this._pairs) {
       set.add(callback(item, id));
     }
 
@@ -191,7 +191,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns A new data stream with the filtered items.
    */
   public filter(callback: (item: Item, id: Id) => boolean): DataStream<Item> {
-    const pairs = this.#pairs;
+    const pairs = this._pairs;
     return new DataStream<Item>({
       *[Symbol.iterator](): IterableIterator<[Id, Item]> {
         for (const [id, item] of pairs) {
@@ -209,7 +209,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @param callback - The function that will be invoked for each item.
    */
   public forEach(callback: (item: Item, id: Id) => boolean): void {
-    for (const [id, item] of this.#pairs) {
+    for (const [id, item] of this._pairs) {
       callback(item, id);
     }
   }
@@ -226,7 +226,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
   public map<Mapped>(
     callback: (item: Item, id: Id) => Mapped
   ): DataStream<Mapped> {
-    const pairs = this.#pairs;
+    const pairs = this._pairs;
     return new DataStream<Mapped>({
       *[Symbol.iterator](): IterableIterator<[Id, Mapped]> {
         for (const [id, item] of pairs) {
@@ -244,7 +244,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns The item with the maximum if found otherwise null.
    */
   public max(callback: (item: Item, id: Id) => number): Item | null {
-    const iter = this.#pairs[Symbol.iterator]();
+    const iter = this._pairs[Symbol.iterator]();
     let curr = iter.next();
     if (curr.done) {
       return null;
@@ -272,7 +272,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
    * @returns The item with the minimum if found otherwise null.
    */
   public min(callback: (item: Item, id: Id) => number): Item | null {
-    const iter = this.#pairs[Symbol.iterator]();
+    const iter = this._pairs[Symbol.iterator]();
     let curr = iter.next();
     if (curr.done) {
       return null;
@@ -306,7 +306,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
     callback: (accumulator: T, item: Item, id: Id) => T,
     accumulator: T
   ): T {
-    for (const [id, item] of this.#pairs) {
+    for (const [id, item] of this._pairs) {
       accumulator = callback(accumulator, item, id);
     }
     return accumulator;
@@ -324,7 +324,7 @@ export class DataStream<Item> implements Iterable<[Id, Item]> {
   ): DataStream<Item> {
     return new DataStream({
       [Symbol.iterator]: (): IterableIterator<[Id, Item]> =>
-        [...this.#pairs]
+        [...this._pairs]
           .sort(([idA, itemA], [idB, itemB]): number =>
             callback(itemA, itemB, idA, idB)
           )

--- a/src/data-view.ts
+++ b/src/data-view.ts
@@ -94,10 +94,10 @@ export class DataView<
     return this.getDataSet().idProp;
   }
 
-  readonly #listener: EventCallbacksWithAny<Item, IdProp>["*"];
-  #data!: DataInterface<Item, IdProp>; // constructor → setData
-  readonly #ids: Set<Id> = new Set(); // ids of the items currently in memory (just contains a boolean true)
-  readonly #options: DataViewOptions<Item, IdProp>;
+  private readonly _listener: EventCallbacksWithAny<Item, IdProp>["*"];
+  private _data!: DataInterface<Item, IdProp>; // constructor → setData
+  private readonly _ids: Set<Id> = new Set(); // ids of the items currently in memory (just contains a boolean true)
+  private readonly _options: DataViewOptions<Item, IdProp>;
 
   /**
    * Create a DataView.
@@ -111,9 +111,9 @@ export class DataView<
   ) {
     super();
 
-    this.#options = options || {};
+    this._options = options || {};
 
-    this.#listener = this._onEvent.bind(this);
+    this._listener = this._onEvent.bind(this);
 
     this.setData(data);
   }
@@ -133,39 +133,39 @@ export class DataView<
    * reference.
    */
   public setData(data: DataInterface<Item, IdProp>): void {
-    if (this.#data) {
+    if (this._data) {
       // unsubscribe from current dataset
-      if (this.#data.off) {
-        this.#data.off("*", this.#listener);
+      if (this._data.off) {
+        this._data.off("*", this._listener);
       }
 
       // trigger a remove of all items in memory
-      const ids = this.#data.getIds({ filter: this.#options.filter });
-      const items = this.#data.get(ids);
+      const ids = this._data.getIds({ filter: this._options.filter });
+      const items = this._data.get(ids);
 
-      this.#ids.clear();
+      this._ids.clear();
       this.length = 0;
       this._trigger("remove", { items: ids, oldData: items });
     }
 
     if (data != null) {
-      this.#data = data;
+      this._data = data;
 
       // trigger an add of all added items
-      const ids = this.#data.getIds({ filter: this.#options.filter });
+      const ids = this._data.getIds({ filter: this._options.filter });
       for (let i = 0, len = ids.length; i < len; i++) {
         const id = ids[i];
-        this.#ids.add(id);
+        this._ids.add(id);
       }
       this.length = ids.length;
       this._trigger("add", { items: ids });
     } else {
-      this.#data = new DataSet<Item, IdProp>();
+      this._data = new DataSet<Item, IdProp>();
     }
 
     // subscribe to new dataset
-    if (this.#data.on) {
-      this.#data.on("*", this.#listener);
+    if (this._data.on) {
+      this._data.on("*", this._listener);
     }
   }
 
@@ -174,10 +174,10 @@ export class DataView<
    * Useful when the DataView has a filter function containing a variable parameter.
    */
   public refresh(): void {
-    const ids = this.#data.getIds({
-      filter: this.#options.filter,
+    const ids = this._data.getIds({
+      filter: this._options.filter,
     });
-    const oldIds = [...this.#ids];
+    const oldIds = [...this._ids];
     const newIds: Record<Id, boolean> = {};
     const addedIds: Id[] = [];
     const removedIds: Id[] = [];
@@ -187,16 +187,16 @@ export class DataView<
     for (let i = 0, len = ids.length; i < len; i++) {
       const id = ids[i];
       newIds[id] = true;
-      if (!this.#ids.has(id)) {
+      if (!this._ids.has(id)) {
         addedIds.push(id);
-        this.#ids.add(id);
+        this._ids.add(id);
       }
     }
 
     // check for removals
     for (let i = 0, len = oldIds.length; i < len; i++) {
       const id = oldIds[i];
-      const item = this.#data.get(id);
+      const item = this._data.get(id);
       if (item == null) {
         // @TODO: Investigate.
         // Doesn't happen during tests or examples.
@@ -206,7 +206,7 @@ export class DataView<
       } else if (!newIds[id]) {
         removedIds.push(id);
         removedItems.push(item);
-        this.#ids.delete(id);
+        this._ids.delete(id);
       }
     }
 
@@ -288,7 +288,7 @@ export class DataView<
     | FullItem<Item, IdProp>
     | FullItem<Item, IdProp>[]
     | Record<string, FullItem<Item, IdProp>> {
-    if (this.#data == null) {
+    if (this._data == null) {
       return null;
     }
 
@@ -305,12 +305,12 @@ export class DataView<
     // extend the options with the default options and provided options
     const viewOptions: DataInterfaceGetOptions<Item> = Object.assign(
       {},
-      this.#options,
+      this._options,
       options
     );
 
     // create a combined filter method when needed
-    const thisFilter = this.#options.filter;
+    const thisFilter = this._options.filter;
     const optionsFilter = options && options.filter;
     if (thisFilter && optionsFilter) {
       viewOptions.filter = (item): boolean => {
@@ -319,16 +319,16 @@ export class DataView<
     }
 
     if (ids == null) {
-      return this.#data.get(viewOptions);
+      return this._data.get(viewOptions);
     } else {
-      return this.#data.get(ids, viewOptions);
+      return this._data.get(ids, viewOptions);
     }
   }
 
   /** @inheritDoc */
   public getIds(options?: DataInterfaceGetIdsOptions<Item>): Id[] {
-    if (this.#data.length) {
-      const defaultFilter = this.#options.filter;
+    if (this._data.length) {
+      const defaultFilter = this._options.filter;
       const optionsFilter = options != null ? options.filter : null;
       let filter: DataInterfaceGetIdsOptions<Item>["filter"];
 
@@ -344,7 +344,7 @@ export class DataView<
         filter = defaultFilter;
       }
 
-      return this.#data.getIds({
+      return this._data.getIds({
         filter: filter,
         order: options && options.order,
       });
@@ -358,8 +358,8 @@ export class DataView<
     callback: (item: Item, id: Id) => void,
     options?: DataInterfaceForEachOptions<Item>
   ): void {
-    if (this.#data) {
-      const defaultFilter = this.#options.filter;
+    if (this._data) {
+      const defaultFilter = this._options.filter;
       const optionsFilter = options && options.filter;
       let filter: undefined | ((item: Item) => boolean);
 
@@ -375,7 +375,7 @@ export class DataView<
         filter = defaultFilter;
       }
 
-      this.#data.forEach(callback, {
+      this._data.forEach(callback, {
         filter: filter,
         order: options && options.order,
       });
@@ -389,8 +389,8 @@ export class DataView<
   ): T[] {
     type Filter = NonNullable<DataInterfaceMapOptions<Item, T>["filter"]>;
 
-    if (this.#data) {
-      const defaultFilter = this.#options.filter;
+    if (this._data) {
+      const defaultFilter = this._options.filter;
       const optionsFilter = options && options.filter;
       let filter: undefined | Filter;
 
@@ -406,7 +406,7 @@ export class DataView<
         filter = defaultFilter;
       }
 
-      return this.#data.map(callback, {
+      return this._data.map(callback, {
         filter: filter,
         order: options && options.order,
       });
@@ -417,14 +417,14 @@ export class DataView<
 
   /** @inheritDoc */
   public getDataSet(): DataSet<Item, IdProp> {
-    return this.#data.getDataSet();
+    return this._data.getDataSet();
   }
 
   /** @inheritDoc */
   public stream(ids?: Iterable<Id>): DataStream<Item> {
-    return this.#data.stream(
+    return this._data.stream(
       ids || {
-        [Symbol.iterator]: this.#ids.keys.bind(this.#ids),
+        [Symbol.iterator]: this._ids.keys.bind(this._ids),
       }
     );
   }
@@ -438,8 +438,8 @@ export class DataView<
    * already. It's stricter version of `dataView.setData(null)`.
    */
   public dispose(): void {
-    if (this.#data?.off) {
-      this.#data.off("*", this.#listener);
+    if (this._data?.off) {
+      this._data.off("*", this._listener);
     }
 
     const message = "This data view has already been disposed of.";
@@ -470,7 +470,7 @@ export class DataView<
     params: EventPayloads<Item, IdProp>[EN],
     senderId?: Id | null
   ): void {
-    if (!params || !params.items || !this.#data) {
+    if (!params || !params.items || !this._data) {
       return;
     }
 
@@ -489,7 +489,7 @@ export class DataView<
           const id = ids[i];
           const item = this.get(id);
           if (item) {
-            this.#ids.add(id);
+            this._ids.add(id);
             addedIds.push(id);
           }
         }
@@ -504,7 +504,7 @@ export class DataView<
           const item = this.get(id);
 
           if (item) {
-            if (this.#ids.has(id)) {
+            if (this._ids.has(id)) {
               updatedIds.push(id);
               updatedItems.push(
                 (params as UpdateEventPayload<Item, IdProp>).data[i]
@@ -513,12 +513,12 @@ export class DataView<
                 (params as UpdateEventPayload<Item, IdProp>).oldData[i]
               );
             } else {
-              this.#ids.add(id);
+              this._ids.add(id);
               addedIds.push(id);
             }
           } else {
-            if (this.#ids.has(id)) {
-              this.#ids.delete(id);
+            if (this._ids.has(id)) {
+              this._ids.delete(id);
               removedIds.push(id);
               removedItems.push(
                 (params as UpdateEventPayload<Item, IdProp>).oldData[i]
@@ -535,8 +535,8 @@ export class DataView<
         // filter the ids of the removed items
         for (let i = 0, len = ids.length; i < len; i++) {
           const id = ids[i];
-          if (this.#ids.has(id)) {
-            this.#ids.delete(id);
+          if (this._ids.has(id)) {
+            this._ids.delete(id);
             removedIds.push(id);
             removedItems.push(
               (params as RemoveEventPayload<Item, IdProp>).oldData[i]

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -54,14 +54,14 @@ export class Queue<T = never> {
   /** Maximum number of entries in the queue before it will be flushed. */
   public max: number;
 
-  readonly #queue: {
+  private readonly _queue: {
     fn: Function;
     args?: unknown[];
     context?: unknown;
   }[] = [];
 
-  #timeout: ReturnType<typeof setTimeout> | null = null;
-  #extended: null | QueueExtended<T> = null;
+  private _timeout: ReturnType<typeof setTimeout> | null = null;
+  private _extended: null | QueueExtended<T> = null;
 
   /**
    * Construct a new Queue.
@@ -134,7 +134,7 @@ export class Queue<T = never> {
       }
     }
 
-    queue.#extended = {
+    queue._extended = {
       object: object,
       methods: methods,
     };
@@ -148,9 +148,9 @@ export class Queue<T = never> {
   public destroy(): void {
     this.flush();
 
-    if (this.#extended) {
-      const object = this.#extended.object;
-      const methods = this.#extended.methods;
+    if (this._extended) {
+      const object = this._extended.object;
+      const methods = this._extended.methods;
       for (let i = 0; i < methods.length; i++) {
         const method = methods[i];
         if (method.original) {
@@ -161,7 +161,7 @@ export class Queue<T = never> {
           delete (object as any)[method.name];
         }
       }
-      this.#extended = null;
+      this._extended = null;
     }
   }
 
@@ -199,9 +199,9 @@ export class Queue<T = never> {
    */
   public queue(entry: QueueCallEntry): void {
     if (typeof entry === "function") {
-      this.#queue.push({ fn: entry });
+      this._queue.push({ fn: entry });
     } else {
-      this.#queue.push(entry);
+      this._queue.push(entry);
     }
 
     this._flushIfNeeded();
@@ -212,17 +212,17 @@ export class Queue<T = never> {
    */
   private _flushIfNeeded(): void {
     // flush when the maximum is exceeded.
-    if (this.#queue.length > this.max) {
+    if (this._queue.length > this.max) {
       this.flush();
     }
 
     // flush after a period of inactivity when a delay is configured
-    if (this.#timeout != null) {
-      clearTimeout(this.#timeout);
-      this.#timeout = null;
+    if (this._timeout != null) {
+      clearTimeout(this._timeout);
+      this._timeout = null;
     }
     if (this.queue.length > 0 && typeof this.delay === "number") {
-      this.#timeout = setTimeout((): void => {
+      this._timeout = setTimeout((): void => {
         this.flush();
       }, this.delay);
     }
@@ -232,7 +232,7 @@ export class Queue<T = never> {
    * Flush all queued calls
    */
   public flush(): void {
-    this.#queue.splice(0).forEach((entry): void => {
+    this._queue.splice(0).forEach((entry): void => {
       entry.fn.apply(entry.context || entry.fn, entry.args || []);
     });
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es2019",
+    "target": "ESNext",
     "typeRoots": ["./@types", "node_modules/@types"]
   },
   "exclude": ["node_modules", "**/__tests__/*"],


### PR DESCRIPTION
Using hard privacy had some unintended consequences:
- TypeScript switches to nominal typing for given class: This flies in the face of my recent efforts to allow third party data views and data sets as TypeScript would mark it as an error even though it would work just fine in JavaScript.
- TypeScript refuses to compile to ES5: I was unable to figure out why but I don't want to force our TS users to add Babel to their build chain just so that we can have hard privacy.

The main advantage of hard privacy was supposed to be that it would prevent reactivity (Vue, Angular etc.) from messing things up but for this to really help people, we would have to have hard privacy everywhere. If there were no issues with it, as I originally though, there would be no problem having it here and eventually and gradually enrolling it elsewhere, but at this point we have the drawbacks without the benefits.

Close #539.