### PR TITLE
chore(deps): install Hammer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "vis-data",
       "version": "0.0.0-no-version",
       "hasInstallScript": true,
       "license": "(Apache-2.0 OR MIT)",
       "devDependencies": {
+        "@egjs/hammerjs": "2.0.17",
         "@rollup/plugin-commonjs": "17.0.0",
         "@rollup/plugin-node-resolve": "11.0.1",
         "@types/chai": "4.2.14",
@@ -1332,6 +1334,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "dev": true,
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
@@ -2152,6 +2166,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
+      "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.6",
@@ -16149,6 +16169,15 @@
         "lazy-ass": "1.6.0"
       }
     },
+    "@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "dev": true,
+      "requires": {
+        "@types/hammerjs": "^2.0.36"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
@@ -16791,6 +16820,12 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/hammerjs": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
+      "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "vis-util": "^4.0.0"
   },
   "devDependencies": {
+    "@egjs/hammerjs": "2.0.17",
     "@rollup/plugin-commonjs": "17.0.0",
     "@rollup/plugin-node-resolve": "11.0.1",
     "@types/chai": "4.2.14",
@@ -168,6 +169,5 @@
     "justinharrell <jharrell@aciss.com>",
     "maik <mauksan@gmail.com>",
     "oliver <oliver@werklaptop2.(none)>"
-  ],
-  "dependencies": {}
+  ]
 }


### PR DESCRIPTION
This should enable Vis Util v5 update. Otherwise it changes nothing, it's just a dev dependency so that TypeScript knows what Hammer is.