### PR TITLE
Allow support of typescript 4.6 and above

### DIFF
--- a/src/data-interface.ts
+++ b/src/data-interface.ts
@@ -76,7 +76,10 @@ export interface AddEventPayload {
   items: Id[];
 }
 /** Update event payload. */
-export interface UpdateEventPayload<Item, IdProp extends string> {
+export interface UpdateEventPayload<
+  Item extends PartItem<IdProp>,
+  IdProp extends string
+> {
   /** Ids of updated items. */
   items: Id[];
   /** Items as they were before this update. */
@@ -89,7 +92,10 @@ export interface UpdateEventPayload<Item, IdProp extends string> {
   data: FullItem<Item, IdProp>[];
 }
 /** Remove event payload. */
-export interface RemoveEventPayload<Item, IdProp extends string> {
+export interface RemoveEventPayload<
+  Item extends PartItem<IdProp>,
+  IdProp extends string
+> {
   /** Ids of removed items. */
   items: Id[];
   /** Items as they were before their removal. */
@@ -102,7 +108,10 @@ export interface RemoveEventPayload<Item, IdProp extends string> {
  * @typeParam Item - Item type that may or may not have an id.
  * @typeParam IdProp - Name of the property that contains the id.
  */
-export interface EventPayloads<Item, IdProp extends string> {
+export interface EventPayloads<
+  Item extends PartItem<IdProp>,
+  IdProp extends string
+> {
   add: AddEventPayload;
   update: UpdateEventPayload<Item, IdProp>;
   remove: RemoveEventPayload<Item, IdProp>;
@@ -113,8 +122,10 @@ export interface EventPayloads<Item, IdProp extends string> {
  * @typeParam Item - Item type that may or may not have an id.
  * @typeParam IdProp - Name of the property that contains the id.
  */
-export interface EventPayloadsWithAny<Item, IdProp extends string>
-  extends EventPayloads<Item, IdProp> {
+export interface EventPayloadsWithAny<
+  Item extends PartItem<IdProp>,
+  IdProp extends string
+> extends EventPayloads<Item, IdProp> {
   "*": ValueOf<EventPayloads<Item, IdProp>>;
 }
 
@@ -124,7 +135,10 @@ export interface EventPayloadsWithAny<Item, IdProp extends string>
  * @typeParam Item - Item type that may or may not have an id.
  * @typeParam IdProp - Name of the property that contains the id.
  */
-export interface EventCallbacks<Item, IdProp extends string> {
+export interface EventCallbacks<
+  Item extends PartItem<IdProp>,
+  IdProp extends string
+> {
   /**
    * @param name - The name of the event ([[EventName]]).
    * @param payload - Data about the items affected by this event.
@@ -158,8 +172,10 @@ export interface EventCallbacks<Item, IdProp extends string> {
  * @typeParam Item - Item type that may or may not have an id.
  * @typeParam IdProp - Name of the property that contains the id.
  */
-export interface EventCallbacksWithAny<Item, IdProp extends string>
-  extends EventCallbacks<Item, IdProp> {
+export interface EventCallbacksWithAny<
+  Item extends PartItem<IdProp>,
+  IdProp extends string
+> extends EventCallbacks<Item, IdProp> {
   /**
    * @param name - The name of the event ([[EventName]]).
    * @param payload - Data about the items affected by this event.

--- a/src/data-set-part.ts
+++ b/src/data-set-part.ts
@@ -5,9 +5,10 @@ import {
   EventNameWithAny,
   EventPayloads,
   Id,
+  PartItem,
 } from "./data-interface";
 
-type EventSubscribers<Item, IdProp extends string> = {
+type EventSubscribers<Item extends PartItem<IdProp>, IdProp extends string> = {
   [Name in keyof EventCallbacksWithAny<Item, IdProp>]: (...args: any[]) => void;
 };
 
@@ -17,8 +18,10 @@ type EventSubscribers<Item, IdProp extends string> = {
  * @typeParam Item - Item type that may or may not have an id.
  * @typeParam IdProp - Name of the property that contains the id.
  */
-export abstract class DataSetPart<Item, IdProp extends string>
-  implements Pick<DataInterface<Item, IdProp>, "on" | "off">
+export abstract class DataSetPart<
+  Item extends PartItem<IdProp>,
+  IdProp extends string
+> implements Pick<DataInterface<Item, IdProp>, "on" | "off">
 {
   private readonly _subscribers: {
     [Name in EventNameWithAny]: EventSubscribers<Item, IdProp>[Name][];


### PR DESCRIPTION
"data-interface.d.ts" and "data-set-part.d.ts" were missing Item extension from PartItem<IdProp>.

This implies compilation errors on typescript 4.6 and above with the following messages :
error TS2344: Type 'Item' does not satisfy the constraint 'Partial<Record<IdProp, OptId>>'

Thanks for the hard work !
Best regards,
Christophe