### PR TITLE
fix(deps): allow v9 of uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     ".*.{js,ts}": "eslint --fix"
   },
   "peerDependencies": {
-    "uuid": "^7.0.0 || ^8.0.0",
+    "uuid": "^7.0.0 || ^8.0.0 || ^9.0.0",
     "vis-util": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We can't update to it as it doesn't work with IE11 (that would be a breaking change) but it should work (at least our tests pass) and if someone wants to, there is no reason to block it.