### PR TITLE
chore(deps): avoid type conflicts by installing @types/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@egjs/hammerjs": "2.0.17",
         "@types/chai": "4.3.10",
         "@types/mocha": "10.0.4",
+        "@types/node": "^20.9.0",
         "@types/sinon": "17.0.1",
         "@types/uuid": "9.0.7",
         "component-emitter": "1.3.0",
@@ -3052,11 +3053,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
       "dev": true,
-      "peer": true
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -6612,6 +6615,13 @@
       "dependencies": {
         "@types/node": "16.9.1"
       }
+    },
+    "node_modules/image-q/node_modules/@types/node": {
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/import-cwd": {
       "version": "3.0.0",
@@ -12553,6 +12563,12 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@egjs/hammerjs": "2.0.17",
     "@types/chai": "4.3.10",
     "@types/mocha": "10.0.4",
+    "@types/node": "^20.9.0",
     "@types/sinon": "17.0.1",
     "@types/uuid": "9.0.7",
     "component-emitter": "1.3.0",


### PR DESCRIPTION
It's only a dep dependency (changes nothing for our users) and it works around an issue where one of our transient dependencies requires an old version of these types. Since we don't specify any version ourselves the old one gets installed at top level and causes issues that has been fixed already. Forcing an up-to-date version works around these issues.