### PR TITLE
docs(deps): remove smooth scroll

### DIFF
--- a/docs/data/datapipe.html
+++ b/docs/data/datapipe.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -27,11 +27,6 @@
 
     <link href="../css/prettify.css" type="text/css" rel="stylesheet" />
     <script type="text/javascript" src="../js/prettify/prettify.js"></script>
-
-    <script src="../js/smooth-scroll.min.js"></script>
-    <script language="JavaScript">
-      smoothScroll.init();
-    </script>
 
     <script type="text/javascript" src="../js/toggleTable.js"></script>
   </head>

--- a/docs/data/dataset.html
+++ b/docs/data/dataset.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -26,11 +26,6 @@
 
     <link href="../css/prettify.css" type="text/css" rel="stylesheet" />
     <script type="text/javascript" src="../js/prettify/prettify.js"></script>
-
-    <script src="../js/smooth-scroll.min.js"></script>
-    <script language="JavaScript">
-      smoothScroll.init();
-    </script>
 
     <script type="text/javascript" src="../js/toggleTable.js"></script>
   </head>

--- a/docs/data/dataview.html
+++ b/docs/data/dataview.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -26,11 +26,6 @@
 
     <link href="../css/prettify.css" type="text/css" rel="stylesheet" />
     <script type="text/javascript" src="../js/prettify/prettify.js"></script>
-
-    <script src="../js/smooth-scroll.min.js"></script>
-    <script language="JavaScript">
-      smoothScroll.init();
-    </script>
 
     <script type="text/javascript" src="../js/toggleTable.js"></script>
   </head>

--- a/docs/data/index.html
+++ b/docs/data/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -26,11 +26,6 @@
 
     <link href="../css/prettify.css" type="text/css" rel="stylesheet" />
     <script type="text/javascript" src="../js/prettify/prettify.js"></script>
-
-    <script src="../js/smooth-scroll.min.js"></script>
-    <script language="JavaScript">
-      smoothScroll.init();
-    </script>
 
     <script type="text/javascript" src="../js/toggleTable.js"></script>
   </head>


### PR DESCRIPTION
This lib is dead, haven't been updated in a long time and I couldn't even find anything in our docs that would scroll smoothly.