### PR TITLE
fix: remove development mode

### DIFF
--- a/src/data-set-part.ts
+++ b/src/data-set-part.ts
@@ -148,10 +148,4 @@ export abstract class DataSetPart<
    */
   public unsubscribe: DataSetPart<Item, IdProp>["off"] =
     DataSetPart.prototype.off;
-
-  /* develblock:start */
-  public get testLeakSubscribers(): any {
-    return this._subscribers;
-  }
-  /* develblock:end */
 }

--- a/src/data-set.ts
+++ b/src/data-set.ts
@@ -1096,22 +1096,4 @@ export class DataSet<
       });
     }
   }
-
-  /* develblock:start */
-  public get testLeakData(): Map<Id, FullItem<Item, IdProp>> {
-    return this._data;
-  }
-  public get testLeakIdProp(): IdProp {
-    return this._idProp;
-  }
-  public get testLeakOptions(): DataSetInitialOptions<IdProp> {
-    return this._options;
-  }
-  public get testLeakQueue(): Queue<this> | null {
-    return this._queue;
-  }
-  public set testLeakQueue(v: Queue<this> | null) {
-    this._queue = v;
-  }
-  /* develblock:end */
 }

--- a/src/entry-esnext.ts
+++ b/src/entry-esnext.ts
@@ -1,7 +1,3 @@
-/* develblock:start */
-console.warn("You're running a development build.");
-/* develblock:end */
-
 export type {
   DataInterface,
   DataInterfaceGetIdsOptions,

--- a/test/DataSet.test.js
+++ b/test/DataSet.test.js
@@ -386,30 +386,75 @@ describe("DataSet", function () {
 
     it("does not update queue when passed an undefined queue", function () {
       var dataset = new DataSet([], { queue: true });
+
+      assert.equal(dataset.length, 0);
+      dataset.add({ id: 1 });
+      assert.equal(dataset.length, 0);
+
       dataset.setOptions({ queue: undefined });
-      assert.notEqual(dataset.testLeakQueue, undefined);
+
+      assert.equal(dataset.length, 0);
+      dataset.add({ id: 2 });
+      assert.equal(dataset.length, 0);
+
+      dataset.flush();
+
+      assert.equal(dataset.length, 2);
+      dataset.add({ id: 3 });
+      assert.equal(dataset.length, 2);
     });
 
     it("destroys the queue when queue set to false", function () {
-      var dataset = new DataSet([]);
+      var dataset = new DataSet([], { queue: true });
+
+      assert.equal(dataset.length, 0);
+      dataset.add({ id: 1 });
+      assert.equal(dataset.length, 0);
+
       dataset.setOptions({ queue: false });
-      assert.equal(dataset.testLeakQueue, undefined);
+
+      assert.equal(dataset.length, 1);
+      dataset.add({ id: 2 });
+      assert.equal(dataset.length, 2);
     });
 
     it("udpates queue options", function () {
-      var dataset = new DataSet([]);
-      dataset.setOptions({ queue: { max: 5, delay: 3 } });
-      assert.equal(dataset.testLeakQueue.max, 5);
-      assert.equal(dataset.testLeakQueue.delay, 3);
+      var dataset = new DataSet([], { queue: true });
+
+      assert.equal(dataset.length, 0);
+      dataset.add({ id: 1 });
+      assert.equal(dataset.length, 0);
+
+      dataset.setOptions({ queue: { max: 5 } });
+
+      assert.equal(dataset.length, 0);
+      dataset.add({ id: 2 });
+      dataset.add({ id: 3 });
+      dataset.add({ id: 4 });
+      dataset.add({ id: 5 });
+      assert.equal(dataset.length, 0);
+      dataset.add({ id: 6 });
+      assert.equal(dataset.length, 6);
     });
 
     it("creates new queue given if none is set", function () {
-      var dataset = new DataSet([], { queue: true });
-      dataset.testLeakQueue.destroy();
-      dataset.testLeakQueue = null;
-      dataset.setOptions({ queue: { max: 5, delay: 3 } });
-      assert.equal(dataset.testLeakQueue.max, 5);
-      assert.equal(dataset.testLeakQueue.delay, 3);
+      var dataset = new DataSet([]);
+
+      assert.equal(dataset.length, 0);
+      dataset.add({ id: 1 });
+      assert.equal(dataset.length, 1);
+
+      dataset.setOptions({ queue: { max: 5 } });
+
+      assert.equal(dataset.length, 1);
+      dataset.add({ id: 2 });
+      dataset.add({ id: 3 });
+      dataset.add({ id: 4 });
+      dataset.add({ id: 5 });
+      dataset.add({ id: 6 });
+      assert.equal(dataset.length, 1);
+      dataset.add({ id: 7 });
+      assert.equal(dataset.length, 7);
     });
   });
 

--- a/test/data-view-dispose.test.ts
+++ b/test/data-view-dispose.test.ts
@@ -17,10 +17,6 @@ describe("Data view dispose", function (): void {
     expect(ds.getIds().sort()).to.deep.equal([1, 2, 3].sort());
 
     dv.dispose();
-    expect(
-      ds.testLeakSubscribers["*"],
-      "Disposed data view should be unsubscribed from it's data set.",
-    ).to.have.lengthOf(0);
     expect((): void => {
       dv.getIds();
     }, "Disposed data view should always throw.").to.throw();


### PR DESCRIPTION
This was used to test the internals but generally it's better to test the public API and not poke inside like this. Stripping of the code also broke some time ago and the getters leaking internal state in tests got released in some builds. Now it's all gone.

I hope nobody used this since it got accidentally released to the public. However it's undocumented and prefixed by `testLeak`, if you depend on something like that 🤷.

closes visjs/vis-timeline#1899